### PR TITLE
Frege Compiler Flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Optional configuration parameters inside `build.gradle`:
 - compilerDownloadDir: defaults to `<projectRoot>/lib`
 - mainSourceDir: defaults to `<projectRoot>/src/main/frege`
 - outputDir: defaults to `<projectRoot>/build/classes/main/frege`
+- compilerFlags: defaults to `['-O', '-make']`
 
 
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group = ch.fhnw.thga
-version = 1.1.0-alpha
+version = 1.2.0-alpha

--- a/src/functionalTest/java/ch/fhnw/thga/gradleplugins/FregePluginFunctionalTest.java
+++ b/src/functionalTest/java/ch/fhnw/thga/gradleplugins/FregePluginFunctionalTest.java
@@ -164,9 +164,8 @@ public class FregePluginFunctionalTest {
         @Test
         void given_frege_code_and_many_compiler_flags() throws Exception {
             String completionFr = "Completion.fr";
-            String buildConfigWithCompilerFlags = createFregeSection(
-                    fregeBuilder.version("'3.25.84'").release("'3.25alpha'")
-                            .compilerFlags("['-v', '-make', '-O', '-hints']").build());
+            String buildConfigWithCompilerFlags = createFregeSection(fregeBuilder.version("'3.25.84'")
+                    .release("'3.25alpha'").compilerFlags("['-v', '-make', '-O', '-hints']").build());
             setupDefaultFregeProjectStructure(SIMPLE_FREGE_CODE, completionFr, buildConfigWithCompilerFlags);
 
             BuildResult result = runGradleTask(COMPILE_FREGE_TASK_NAME);
@@ -179,7 +178,19 @@ public class FregePluginFunctionalTest {
             assertTrue(new File(
                     testProjectDir.getAbsolutePath() + "/build/classes/main/frege/ch/fhnw/thga/Completion.class")
                             .exists());
+        }
 
+        @Test
+        void given_frege_code_and_illegal_compiler_flags() throws Exception {
+            String completionFr = "Completion.fr";
+            String buildConfigWithIllegalCompilerFlags = createFregeSection(fregeBuilder.version("'3.25.84'")
+                    .release("'3.25alpha'").compilerFlags("['-make', '-bla']").build());
+            setupDefaultFregeProjectStructure(SIMPLE_FREGE_CODE, completionFr, buildConfigWithIllegalCompilerFlags);
+
+            BuildResult result = runAndFailGradleTask(COMPILE_FREGE_TASK_NAME);
+
+            assertTrue(project.getTasks().getByName(COMPILE_FREGE_TASK_NAME) instanceof CompileFregeTask);
+            assertEquals(FAILED, result.task(":" + COMPILE_FREGE_TASK_NAME).getOutcome());
         }
 
         @Test

--- a/src/functionalTest/java/ch/fhnw/thga/gradleplugins/FregePluginFunctionalTest.java
+++ b/src/functionalTest/java/ch/fhnw/thga/gradleplugins/FregePluginFunctionalTest.java
@@ -35,11 +35,9 @@ import org.junit.jupiter.api.io.TempDir;
 @TestInstance(Lifecycle.PER_CLASS)
 public class FregePluginFunctionalTest {
     private static final String NEW_LINE = System.lineSeparator();
-    private static final String SIMPLE_FREGE_CODE = String.join(NEW_LINE,
-          "module ch.fhnw.thga.Completion where", NEW_LINE,
-          NEW_LINE,
-          "  complete :: Int -> (Int, String)", NEW_LINE,
-          "  complete i = (i, \"Frege rocks\")", NEW_LINE);
+    private static final String SIMPLE_FREGE_CODE = String.join(NEW_LINE, "module ch.fhnw.thga.Completion where",
+            NEW_LINE, NEW_LINE, "  complete :: Int -> (Int, String)", NEW_LINE, "  complete i = (i, \"Frege rocks\")",
+            NEW_LINE);
 
     private static FregeDTOBuilder fregeBuilder;
 
@@ -77,10 +75,10 @@ public class FregePluginFunctionalTest {
                 .buildAndFail();
     }
 
-    private void setupDefaultFregeProjectStructure(String fregeCode, String fregeFileName, String buildFileConfig) throws Exception {
+    private void setupDefaultFregeProjectStructure(String fregeCode, String fregeFileName, String buildFileConfig)
+            throws Exception {
         Files.createDirectories(testProjectDir.toPath().resolve(Paths.get("src", "main", "frege")));
-        File fregeFile = testProjectDir.toPath().resolve(Paths.get("src", "main", "frege", fregeFileName))
-                .toFile();
+        File fregeFile = testProjectDir.toPath().resolve(Paths.get("src", "main", "frege", fregeFileName)).toFile();
         writeToFile(fregeFile, fregeCode);
         appendToFile(buildFile, buildFileConfig);
     }
@@ -164,6 +162,27 @@ public class FregePluginFunctionalTest {
         }
 
         @Test
+        void given_frege_code_and_many_compiler_flags() throws Exception {
+            String completionFr = "Completion.fr";
+            String buildConfigWithCompilerFlags = createFregeSection(
+                    fregeBuilder.version("'3.25.84'").release("'3.25alpha'")
+                            .compilerFlags("['-v', '-make', '-O', '-hints']").build());
+            setupDefaultFregeProjectStructure(SIMPLE_FREGE_CODE, completionFr, buildConfigWithCompilerFlags);
+
+            BuildResult result = runGradleTask(COMPILE_FREGE_TASK_NAME);
+
+            assertTrue(project.getTasks().getByName(COMPILE_FREGE_TASK_NAME) instanceof CompileFregeTask);
+            assertEquals(SUCCESS, result.task(":" + COMPILE_FREGE_TASK_NAME).getOutcome());
+            assertTrue(new File(
+                    testProjectDir.getAbsolutePath() + "/build/classes/main/frege/ch/fhnw/thga/Completion.java")
+                            .exists());
+            assertTrue(new File(
+                    testProjectDir.getAbsolutePath() + "/build/classes/main/frege/ch/fhnw/thga/Completion.class")
+                            .exists());
+
+        }
+
+        @Test
         void given_frege_code_in_custom_source_dir_and_custom_output_dir_and_minimal_build_file_config()
                 throws Exception {
             Path customMainSourceDir = testProjectDir.toPath().resolve(Paths.get("src", "frege"));
@@ -196,8 +215,7 @@ public class FregePluginFunctionalTest {
                     "  main = do", NEW_LINE, "    println \"Frege rocks\"", NEW_LINE);
             String mainFr = "Main.fr";
             String buildFileConfig = createFregeSection(
-                    fregeBuilder.version("'3.25.84'").release("'3.25alpha'")
-                    .mainModule("'ch.fhnw.thga.Main'").build());
+                    fregeBuilder.version("'3.25.84'").release("'3.25alpha'").mainModule("'ch.fhnw.thga.Main'").build());
             setupDefaultFregeProjectStructure(fregeCode, mainFr, buildFileConfig);
 
             BuildResult result = runGradleTask(RUN_FREGE_TASK_NAME);
@@ -209,9 +227,8 @@ public class FregePluginFunctionalTest {
         @Test
         void given_frege_file_without_main_function() throws Exception {
             String completionFr = "Completion.fr";
-            String buildFileConfig = createFregeSection(
-                    fregeBuilder.version("'3.25.84'").release("'3.25alpha'")
-                            .mainModule("'ch.fhnw.thga.Completion'").build());
+            String buildFileConfig = createFregeSection(fregeBuilder.version("'3.25.84'").release("'3.25alpha'")
+                    .mainModule("'ch.fhnw.thga.Completion'").build());
             setupDefaultFregeProjectStructure(SIMPLE_FREGE_CODE, completionFr, buildFileConfig);
 
             BuildResult result = runAndFailGradleTask(RUN_FREGE_TASK_NAME);

--- a/src/main/java/ch/fhnw/thga/gradleplugins/FregeExtension.java
+++ b/src/main/java/ch/fhnw/thga/gradleplugins/FregeExtension.java
@@ -1,9 +1,12 @@
 package ch.fhnw.thga.gradleplugins;
 
+import java.util.List;
+
 import javax.inject.Inject;
 
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.ProjectLayout;
+import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
 
 public abstract class FregeExtension {
@@ -22,11 +25,13 @@ public abstract class FregeExtension {
 
     public abstract DirectoryProperty getOutputDir();
 
+    public abstract ListProperty<String> getCompilerFlags();
+
     @Inject
     public FregeExtension(ProjectLayout projectLayout) {
         getCompilerDownloadDir().convention(projectLayout.getProjectDirectory().dir(DEFAULT_DOWNLOAD_DIRECTORY));
         getMainSourceDir().convention(projectLayout.getProjectDirectory());
         getOutputDir().convention(projectLayout.getBuildDirectory().dir(DEFAULT_RELATIVE_OUTPUT_DIR));
+        getCompilerFlags().convention(List.of("-O", "-make"));
     }
-
 }

--- a/src/main/java/ch/fhnw/thga/gradleplugins/FregePlugin.java
+++ b/src/main/java/ch/fhnw/thga/gradleplugins/FregePlugin.java
@@ -27,6 +27,7 @@ public class FregePlugin implements Plugin<Project> {
                     task.getFregeCompilerJar().set(setupFregeCompilerTask.get().getFregeCompilerOutputPath());
                     task.getFregeMainSourceDir().set(extension.getMainSourceDir());
                     task.getFregeOutputDir().set(extension.getOutputDir());
+                    task.getFregeCompilerFlags().set(extension.getCompilerFlags());
                 });
         project.getTasks().register(RUN_FREGE_TASK_NAME, RunFregeTask.class, task -> {
             task.dependsOn(compileFregeTask);

--- a/src/main/java/ch/fhnw/thga/gradleplugins/SetupFregeTask.java
+++ b/src/main/java/ch/fhnw/thga/gradleplugins/SetupFregeTask.java
@@ -40,7 +40,7 @@ public abstract class SetupFregeTask extends DefaultTask {
     }
 
     @Internal
-    public Provider<String> getDownloadUrl() {
+    final public Provider<String> getDownloadUrl() {
         return getFregeVersionJarName()
                 .map(name -> String.join("/", FREGE_GITHUB_URL_PREFIX, getRelease().get(), name));
     }

--- a/src/test/java/ch/fhnw/thga/gradleplugins/Builder.java
+++ b/src/test/java/ch/fhnw/thga/gradleplugins/Builder.java
@@ -13,5 +13,7 @@ public interface Builder {
 
     Builder mainModule(String mainModule);
 
+    Builder compilerFlags(String compilerFlags);
+
     FregeDTO build();
 }

--- a/src/test/java/ch/fhnw/thga/gradleplugins/FregeDTO.java
+++ b/src/test/java/ch/fhnw/thga/gradleplugins/FregeDTO.java
@@ -13,15 +13,17 @@ public class FregeDTO {
     public final String mainSourceDir;
     public final String outputDir;
     public final String mainModule;
+    public final String compilerFlags;
 
     public FregeDTO(String version, String release, String compilerDownloadDir, String mainSourceDir,
-            String outputDir, String mainModule) {
+            String outputDir, String mainModule, String compilerFlags) {
         this.version = version;
         this.release = release;
         this.compilerDownloadDir = compilerDownloadDir;
         this.mainSourceDir = mainSourceDir;
         this.outputDir = outputDir;
         this.mainModule = mainModule;
+        this.compilerFlags = compilerFlags;
     }
 
     public String getVersion() {
@@ -46,6 +48,10 @@ public class FregeDTO {
 
     public String getMainModule() {
         return mainModule;
+    }
+
+    public String getCompilerFlags() {
+        return compilerFlags;
     }
 
     private String getFieldValue(Field field) {

--- a/src/test/java/ch/fhnw/thga/gradleplugins/FregeDTOBuilder.java
+++ b/src/test/java/ch/fhnw/thga/gradleplugins/FregeDTOBuilder.java
@@ -7,6 +7,7 @@ public final class FregeDTOBuilder implements Builder {
     private String mainSourceDir = "";
     private String outputDir = "";
     private String mainModule = "";
+    private String compilerFlags = "";
 
     private static volatile FregeDTOBuilder instance;
 
@@ -65,7 +66,13 @@ public final class FregeDTOBuilder implements Builder {
         return this;
     }
 
+    @Override
+    public Builder compilerFlags(String compilerFlags) {
+        this.compilerFlags = compilerFlags;
+        return this;
+    }
+
     public FregeDTO build() {
-        return new FregeDTO(version, release, compilerDownloadDir, mainSourceDir, outputDir, mainModule);
+        return new FregeDTO(version, release, compilerDownloadDir, mainSourceDir, outputDir, mainModule, compilerFlags);
     }
 }


### PR DESCRIPTION
Adds a `compilerFlags` property to configure the Frege compiler in the `build.gradle` file.