### PR TITLE
Dependent Frege Files

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group = ch.fhnw.thga
-version = 1.3.0-alpha
+version = 1.3.1-alpha


### PR DESCRIPTION
If a Frege module A depends on Frege module B, then you need to
compile with the `-make` flag so that the compiler resolves the
dependencies and compiles the module B before the module A.