### PR TITLE
Implementation Dependency Configuration

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group = ch.fhnw.thga
-version = 1.3.1-alpha
+version = 1.3.2-alpha

--- a/src/main/java/ch/fhnw/thga/gradleplugins/FregePlugin.java
+++ b/src/main/java/ch/fhnw/thga/gradleplugins/FregePlugin.java
@@ -2,6 +2,7 @@ package ch.fhnw.thga.gradleplugins;
 
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.tasks.TaskProvider;
 
 public class FregePlugin implements Plugin<Project> {
@@ -10,9 +11,11 @@ public class FregePlugin implements Plugin<Project> {
     public static final String RUN_FREGE_TASK_NAME = "runFrege";
     public static final String FREGE_PLUGIN_ID = "ch.fhnw.thga.frege";
     public static final String FREGE_EXTENSION_NAME = "frege";
+    public static final String FREGE_IMPLEMENTATION_SCOPE = "implementation";
 
     @Override
     public void apply(Project project) {
+        Configuration implementation = project.getConfigurations().create(FREGE_IMPLEMENTATION_SCOPE);
         FregeExtension extension = project.getExtensions().create(FREGE_EXTENSION_NAME, FregeExtension.class);
         TaskProvider<SetupFregeTask> setupFregeCompilerTask = project.getTasks().register(SETUP_FREGE_TASK_NAME,
                 SetupFregeTask.class, task -> {
@@ -28,6 +31,7 @@ public class FregePlugin implements Plugin<Project> {
                     task.getFregeMainSourceDir().set(extension.getMainSourceDir());
                     task.getFregeOutputDir().set(extension.getOutputDir());
                     task.getFregeCompilerFlags().set(extension.getCompilerFlags());
+                    task.getFregeDependencies().set(implementation.getAsPath());
                 });
         project.getTasks().register(RUN_FREGE_TASK_NAME, RunFregeTask.class, task -> {
             task.dependsOn(compileFregeTask);


### PR DESCRIPTION
Allows to configure the Frege compile classpath with the groovy dependency notation in the `build.gradle` file.

E.g.:

```groovy
dependencies {
    implementation 'org.frege-lang:fregefx:0.8.2-SNAPSHOT'
}
```