### PR TITLE
Adds `replFrege` Task

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Optional configuration parameters inside `build.gradle`:
 - **setupFrege**: Downloads the specified version of the Frege compiler.
 - **compileFrege**: All your `*.fr` files in `mainSourceDir` get compiled to `outputDir`.
 - **runFrege**: Runs the Frege module specified by `mainModule`. Alternatively you can also pass the main module by command line, e.g: `gradle runFrege --mainModule=my.mod.Name`.
+- **replFrege**: Starts the Frege REPL with the Frege compiler, `outputDir` and specified `dependencies` on the classpath.
 
 ### Compile Dependencies
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group = ch.fhnw.thga
-version = 1.3.2-alpha
+version = 1.4.0-alpha

--- a/src/functionalTest/java/ch/fhnw/thga/gradleplugins/FregePluginFunctionalTest.java
+++ b/src/functionalTest/java/ch/fhnw/thga/gradleplugins/FregePluginFunctionalTest.java
@@ -1,11 +1,7 @@
 package ch.fhnw.thga.gradleplugins;
 
 import static ch.fhnw.thga.gradleplugins.FregeExtension.DEFAULT_DOWNLOAD_DIRECTORY;
-import static ch.fhnw.thga.gradleplugins.FregePlugin.COMPILE_FREGE_TASK_NAME;
-import static ch.fhnw.thga.gradleplugins.FregePlugin.FREGE_EXTENSION_NAME;
-import static ch.fhnw.thga.gradleplugins.FregePlugin.FREGE_PLUGIN_ID;
-import static ch.fhnw.thga.gradleplugins.FregePlugin.RUN_FREGE_TASK_NAME;
-import static ch.fhnw.thga.gradleplugins.FregePlugin.SETUP_FREGE_TASK_NAME;
+import static ch.fhnw.thga.gradleplugins.FregePlugin.*;
 import static ch.fhnw.thga.gradleplugins.GradleBuildFileConversionTest.createPluginsSection;
 import static org.gradle.testkit.runner.TaskOutcome.FAILED;
 import static org.gradle.testkit.runner.TaskOutcome.FROM_CACHE;
@@ -33,6 +29,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.IndicativeSentencesGeneration;
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
@@ -354,6 +351,24 @@ public class FregePluginFunctionalTest {
             assertTrue(project.getTasks().getByName(RUN_FREGE_TASK_NAME) instanceof RunFregeTask);
             assertEquals(SUCCESS, result.task(":" + RUN_FREGE_TASK_NAME).getOutcome());
             assertTrue(result.getOutput().contains("Frege rocks"));
+        }
+    }
+
+    @Nested
+    @TestInstance(Lifecycle.PER_CLASS)
+    @IndicativeSentencesGeneration(separator = " -> ", generator = DisplayNameGenerator.ReplaceUnderscores.class)
+    class Repl_frege_task_works {
+        @Test
+        @Tag("hard")
+        void given_minimal_build_file_config() throws Exception {
+            Files.createDirectories(testProjectDir.toPath().resolve(Paths.get("src", "main", "frege")));
+            String minimalBuildFileConfig = createFregeSection(
+                    fregeBuilder.version("'3.25.84'").release("'3.25alpha'").build());
+            appendToFile(buildFile, minimalBuildFileConfig);
+
+            BuildResult result = runGradleTask(REPL_FREGE_TASK_NAME);
+            assertTrue(project.getTasks().getByName(REPL_FREGE_TASK_NAME) instanceof ReplFregeTask);
+            assertEquals(SUCCESS, result.task(":" + REPL_FREGE_TASK_NAME).getOutcome());
         }
     }
 }

--- a/src/main/java/ch/fhnw/thga/gradleplugins/FregePlugin.java
+++ b/src/main/java/ch/fhnw/thga/gradleplugins/FregePlugin.java
@@ -9,6 +9,7 @@ public class FregePlugin implements Plugin<Project> {
     public static final String SETUP_FREGE_TASK_NAME = "setupFrege";
     public static final String COMPILE_FREGE_TASK_NAME = "compileFrege";
     public static final String RUN_FREGE_TASK_NAME = "runFrege";
+    public static final String REPL_FREGE_TASK_NAME = "replFrege";
     public static final String FREGE_PLUGIN_ID = "ch.fhnw.thga.frege";
     public static final String FREGE_EXTENSION_NAME = "frege";
     public static final String FREGE_IMPLEMENTATION_SCOPE = "implementation";
@@ -38,6 +39,13 @@ public class FregePlugin implements Plugin<Project> {
             task.getFregeCompilerJar().set(setupFregeCompilerTask.get().getFregeCompilerOutputPath());
             task.getFregeOutputDir().set(extension.getOutputDir());
             task.getMainModule().set(extension.getMainModule());
+            task.getFregeDependencies().set(implementation.getAsPath());
+        });
+        project.getTasks().register(REPL_FREGE_TASK_NAME, ReplFregeTask.class, task -> {
+            task.dependsOn(compileFregeTask);
+            task.getFregeCompilerJar().set(setupFregeCompilerTask.get().getFregeCompilerOutputPath());
+            task.getFregeOutputDir().set(extension.getOutputDir());
+            task.getFregeDependencies().set(implementation.getAsPath());
         });
     }
 }

--- a/src/main/java/ch/fhnw/thga/gradleplugins/ReplFregeTask.java
+++ b/src/main/java/ch/fhnw/thga/gradleplugins/ReplFregeTask.java
@@ -17,10 +17,11 @@ import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.JavaExec;
 import org.gradle.api.tasks.TaskAction;
-import org.gradle.api.tasks.options.Option;
 
-public abstract class RunFregeTask extends DefaultTask {
+public abstract class ReplFregeTask extends DefaultTask {
     public static final Logger LOGGER = Logging.getLogger(SetupFregeTask.class);
+    public static final String REPL_MAIN_CLASS = "frege.repl.FregeRepl";
+
     private final JavaExec javaExec;
 
     @InputFile
@@ -28,10 +29,6 @@ public abstract class RunFregeTask extends DefaultTask {
 
     @InputDirectory
     public abstract DirectoryProperty getFregeOutputDir();
-
-    @Input
-    @Option(option = "mainModule", description = "The full name of the Frege module with a main function, e.g. 'my.mod.Name'")
-    public abstract Property<String> getMainModule();
 
     @Input
     public abstract Property<String> getFregeDependencies();
@@ -45,13 +42,13 @@ public abstract class RunFregeTask extends DefaultTask {
     }
 
     @Inject
-    public RunFregeTask(ObjectFactory objectFactory) {
+    public ReplFregeTask(ObjectFactory objectFactory) {
         javaExec = objectFactory.newInstance(JavaExec.class);
     }
 
     @TaskAction
-    public void runFrege() {
-        javaExec.getMainClass().set(getMainModule());
+    public void startFregeRepl() {
+        javaExec.getMainClass().set(REPL_MAIN_CLASS);
         javaExec.setClasspath(getClasspath().get()).exec();
     }
 }


### PR DESCRIPTION
Adds `replFrege` Task, which starts the Frege REPL with with the Frege compiler, `outputDir` and specified `dependencies` on the classpath.