### PR TITLE
Repl with all Source Dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,14 @@ git clone https://github.com/tricktron/frege-gradle-plugin.git
 ```
 
 ## How to Use
-1. Specify the frege compiler release, version and main module in your `build.gradle`:
+1. Specify the frege compiler release, version, main module and repl source file in your `build.gradle`:
 
 ```groovy
 frege {
     version = '3.25.84'
     release = '3.25alpha'
-    mainModule = 'my.mod.Name'
+    mainModule = 'my.mod.Name' // see runFrege task
+    replSource = 'Name.fr' // see replFrege task
 }
 ```
 
@@ -35,7 +36,7 @@ Optional configuration parameters inside `build.gradle`:
 - **setupFrege**: Downloads the specified version of the Frege compiler.
 - **compileFrege**: All your `*.fr` files in `mainSourceDir` get compiled to `outputDir`.
 - **runFrege**: Runs the Frege module specified by `mainModule`. Alternatively you can also pass the main module by command line, e.g: `gradle runFrege --mainModule=my.mod.Name`.
-- **replFrege**: Takes care of all project dependencies and prints the command to start the Frege REPL, e.g: `java -cp <your-correct-classpath-with-all-dependencies> frege.repl.FregeRepl`.
+- **replFrege**: Takes care of all project dependencies of the specified filename by `replSource` and prints the command to start the Frege REPL, e.g: `java -cp <your-correct-classpath-with-all-dependencies> frege.repl.FregeRepl`. Afterwards you can load your file into the repl with `:l <absolute path to replSource>`.
 
 ### Dependencies
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group = ch.fhnw.thga
-version = 1.5.0-alpha
+version = 1.6.0-alpha

--- a/src/functionalTest/java/ch/fhnw/thga/gradleplugins/FregePluginFunctionalTest.java
+++ b/src/functionalTest/java/ch/fhnw/thga/gradleplugins/FregePluginFunctionalTest.java
@@ -2,18 +2,19 @@ package ch.fhnw.thga.gradleplugins;
 
 import static ch.fhnw.thga.gradleplugins.FregeExtension.DEFAULT_DOWNLOAD_DIRECTORY;
 import static ch.fhnw.thga.gradleplugins.FregePlugin.COMPILE_FREGE_TASK_NAME;
+import static ch.fhnw.thga.gradleplugins.FregePlugin.DEPS_FREGE_TASK_NAME;
 import static ch.fhnw.thga.gradleplugins.FregePlugin.FREGE_EXTENSION_NAME;
 import static ch.fhnw.thga.gradleplugins.FregePlugin.FREGE_PLUGIN_ID;
-import static ch.fhnw.thga.gradleplugins.FregePlugin.DEPS_FREGE_TASK_NAME;
+import static ch.fhnw.thga.gradleplugins.FregePlugin.REPL_FREGE_TASK_NAME;
 import static ch.fhnw.thga.gradleplugins.FregePlugin.RUN_FREGE_TASK_NAME;
 import static ch.fhnw.thga.gradleplugins.FregePlugin.SETUP_FREGE_TASK_NAME;
-import static ch.fhnw.thga.gradleplugins.FregePlugin.REPL_FREGE_TASK_NAME;
 import static ch.fhnw.thga.gradleplugins.GradleBuildFileConversionTest.createPluginsSection;
 import static org.gradle.testkit.runner.TaskOutcome.FAILED;
 import static org.gradle.testkit.runner.TaskOutcome.FROM_CACHE;
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS;
 import static org.gradle.testkit.runner.TaskOutcome.UP_TO_DATE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.BufferedWriter;
@@ -44,407 +45,512 @@ import ch.fhnw.thga.gradleplugins.internal.DependencyFregeTask;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class FregePluginFunctionalTest {
-        private static final String NEW_LINE = System.lineSeparator();
-        private static final String SIMPLE_FREGE_CODE = String.join(NEW_LINE, "module ch.fhnw.thga.Completion where",
-                        NEW_LINE, NEW_LINE, "  complete :: Int -> (Int, String)", NEW_LINE,
-                        "  complete i = (i, \"Frege rocks\")",
-                        NEW_LINE);
+    private static final String NEW_LINE = System.lineSeparator();
+    private static final String SIMPLE_FREGE_CODE = String.join(NEW_LINE, "module ch.fhnw.thga.Completion where",
+                    NEW_LINE, NEW_LINE, "  complete :: Int -> (Int, String)", NEW_LINE,
+                    "  complete i = (i, \"Frege rocks\")",
+                    NEW_LINE);
 
-        private static FregeDTOBuilder fregeBuilder;
+    private static FregeDTOBuilder fregeBuilder;
 
-        @TempDir
-        File testProjectDir;
-        private File buildFile;
-        private File settingsFile;
-        private Project project;
+    @TempDir
+    File testProjectDir;
+    private File buildFile;
+    private File settingsFile;
+    private Project project;
 
-        private void writeFile(File destination, String content, boolean append) throws IOException {
-                try (BufferedWriter output = new BufferedWriter(new FileWriter(destination, append))) {
-                        output.write(content);
-                }
+    private void writeFile(File destination, String content, boolean append) throws IOException {
+            try (BufferedWriter output = new BufferedWriter(new FileWriter(destination, append))) {
+                    output.write(content);
+            }
+    }
+
+    private void writeToFile(File destination, String content) throws IOException {
+            writeFile(destination, content, false);
+    }
+
+    private void appendToFile(File destination, String content) throws IOException {
+            writeFile(destination, System.lineSeparator() + content, true);
+    }
+
+    private static String createFregeSection(FregeDTO fregeDTO) {
+            return String.format(
+                "%s {%s  %s%s}",
+                FREGE_EXTENSION_NAME,
+                System.lineSeparator(),
+                fregeDTO.toBuildFile(),
+                System.lineSeparator());
+    }
+
+    private BuildResult runGradleTask(String... taskName) {
+            return GradleRunner.create().withProjectDir(testProjectDir).withPluginClasspath()
+                            .withArguments(taskName)
+                            .build();
+    }
+
+    private BuildResult runAndFailGradleTask(String taskName, String... args) {
+            return GradleRunner.create().withProjectDir(testProjectDir).withPluginClasspath()
+                            .withArguments(taskName)
+                            .buildAndFail();
+    }
+
+    private void setupDefaultFregeProjectStructure(String fregeCode, String fregeFileName, String buildFileConfig)
+                    throws Exception {
+            Files.createDirectories(testProjectDir.toPath().resolve(Paths.get("src", "main", "frege")));
+            File fregeFile = testProjectDir.toPath().resolve(Paths.get("src", "main", "frege", fregeFileName))
+                            .toFile();
+            writeToFile(fregeFile, fregeCode);
+            appendToFile(buildFile, buildFileConfig);
+    }
+
+    @BeforeAll
+    void beforeAll() throws Exception {
+            settingsFile = new File(testProjectDir, "settings.gradle");
+            writeToFile(settingsFile, "rootProject.name='frege-plugin'");
+            project = ProjectBuilder.builder().withProjectDir(testProjectDir).build();
+            project.getPluginManager().apply(FREGE_PLUGIN_ID);
+
+    }
+
+    @BeforeEach
+    void setup() throws Exception {
+            buildFile = new File(testProjectDir, "build.gradle");
+            writeToFile(buildFile, createPluginsSection(Stream.of(FREGE_PLUGIN_ID)));
+            fregeBuilder = FregeDTOBuilder.getInstance();
+    }
+
+    @AfterEach
+    void cleanup() {
+            testProjectDir.delete();
+    }
+
+    @Nested
+    @TestInstance(Lifecycle.PER_CLASS)
+    @IndicativeSentencesGeneration(separator = " -> ", generator = DisplayNameGenerator.ReplaceUnderscores.class)
+    class Setup_frege_task_works {
+
+            @Test
+            void given_minimal_build_file_config() throws Exception {
+                    String minimalBuildFileConfig = createFregeSection(
+                                    fregeBuilder.version("'3.25.84'").release("'3.25alpha'").build());
+                    appendToFile(buildFile, minimalBuildFileConfig);
+
+                    BuildResult result = runGradleTask(SETUP_FREGE_TASK_NAME);
+
+                    assertTrue(project.getTasks().getByName(SETUP_FREGE_TASK_NAME) instanceof SetupFregeTask);
+                    assertEquals(SUCCESS, result.task(":" + SETUP_FREGE_TASK_NAME).getOutcome());
+                    assertTrue(testProjectDir.toPath()
+                                    .resolve(Paths.get(DEFAULT_DOWNLOAD_DIRECTORY, "frege3.25.84.jar"))
+                                    .toFile().exists());
+            }
+
+            @Test
+            void given_custom_frege_compiler_download_directory_in_build_file_config() throws Exception {
+                    String buildFileConfigWithCustomDownloadDir = createFregeSection(fregeBuilder
+                                    .version("'3.25.84'")
+                                    .release("'3.25alpha'")
+                                    .compilerDownloadDir("layout.projectDirectory.dir('dist')").build());
+                    appendToFile(buildFile, buildFileConfigWithCustomDownloadDir);
+
+                    BuildResult result = runGradleTask(SETUP_FREGE_TASK_NAME);
+
+                    assertTrue(project.getTasks().getByName(SETUP_FREGE_TASK_NAME) instanceof SetupFregeTask);
+                    assertEquals(SUCCESS, result.task(":" + SETUP_FREGE_TASK_NAME).getOutcome());
+                    assertTrue(testProjectDir.toPath().resolve(Paths.get("dist", "frege3.25.84.jar")).toFile()
+                                    .exists());
+            }
+    }
+
+    @Nested
+    @TestInstance(Lifecycle.PER_CLASS)
+    @IndicativeSentencesGeneration(separator = " -> ", generator = DisplayNameGenerator.ReplaceUnderscores.class)
+    class Compile_frege_task_works {
+
+            @Test
+            void given_frege_code_in_default_source_dir_and_minimal_build_file_config() throws Exception {
+                    String completionFr = "Completion.fr";
+                    String minimalBuildFileConfig = createFregeSection(
+                                    fregeBuilder.version("'3.25.84'").release("'3.25alpha'").build());
+                    setupDefaultFregeProjectStructure(SIMPLE_FREGE_CODE, completionFr, minimalBuildFileConfig);
+
+                    BuildResult result = runGradleTask(COMPILE_FREGE_TASK_NAME);
+
+                    assertTrue(project.getTasks().getByName(COMPILE_FREGE_TASK_NAME) instanceof CompileFregeTask);
+                    assertEquals(SUCCESS, result.task(":" + COMPILE_FREGE_TASK_NAME).getOutcome());
+                    assertTrue(new File(
+                                    testProjectDir.getAbsolutePath()
+                                                    + "/build/classes/main/frege/ch/fhnw/thga/Completion.java")
+                                                                    .exists());
+                    assertTrue(new File(
+                                    testProjectDir.getAbsolutePath()
+                                                    + "/build/classes/main/frege/ch/fhnw/thga/Completion.class")
+                                                                    .exists());
+            }
+
+            @Test
+            void given_frege_code_and_many_compiler_flags() throws Exception {
+                    String completionFr = "Completion.fr";
+                    String buildConfigWithCompilerFlags = createFregeSection(fregeBuilder.version("'3.25.84'")
+                                    .release("'3.25alpha'").compilerFlags("['-v', '-make', '-O', '-hints']")
+                                    .build());
+                    setupDefaultFregeProjectStructure(SIMPLE_FREGE_CODE, completionFr,
+                                    buildConfigWithCompilerFlags);
+
+                    BuildResult result = runGradleTask(COMPILE_FREGE_TASK_NAME);
+
+                    assertTrue(project.getTasks().getByName(COMPILE_FREGE_TASK_NAME) instanceof CompileFregeTask);
+                    assertEquals(SUCCESS, result.task(":" + COMPILE_FREGE_TASK_NAME).getOutcome());
+                    assertTrue(new File(
+                                    testProjectDir.getAbsolutePath()
+                                                    + "/build/classes/main/frege/ch/fhnw/thga/Completion.java")
+                                                                    .exists());
+                    assertTrue(new File(
+                                    testProjectDir.getAbsolutePath()
+                                                    + "/build/classes/main/frege/ch/fhnw/thga/Completion.class")
+                                                                    .exists());
+            }
+
+            @Test
+            void given_frege_code_in_custom_source_dir_and_custom_output_dir_and_minimal_build_file_config()
+                            throws Exception {
+                    Path customMainSourceDir = testProjectDir.toPath().resolve(Paths.get("src", "frege"));
+                    Files.createDirectories(customMainSourceDir);
+                    File completionFr = customMainSourceDir.resolve("Completion.fr").toFile();
+                    writeToFile(completionFr, SIMPLE_FREGE_CODE);
+                    String minimalBuildFileConfig = createFregeSection(
+                                    fregeBuilder.version("'3.25.84'").release("'3.25alpha'")
+                                                    .mainSourceDir("layout.projectDirectory.dir('src/frege')")
+                                                    .outputDir("layout.buildDirectory.dir('frege')").build());
+                    appendToFile(buildFile, minimalBuildFileConfig);
+
+                    BuildResult result = runGradleTask(COMPILE_FREGE_TASK_NAME);
+
+                    assertTrue(project.getTasks().getByName(COMPILE_FREGE_TASK_NAME) instanceof CompileFregeTask);
+                    assertEquals(SUCCESS, result.task(":" + COMPILE_FREGE_TASK_NAME).getOutcome());
+                    assertTrue(
+                                    new File(testProjectDir.getAbsolutePath()
+                                                    + "/build/frege/ch/fhnw/thga/Completion.java").exists());
+                    assertTrue(
+                                    new File(testProjectDir.getAbsolutePath()
+                                                    + "/build/frege/ch/fhnw/thga/Completion.class").exists());
+            }
+
+            @Test
+            void and_is_up_to_date_given_no_code_changes() throws Exception {
+                    String completionFr = "Completion.fr";
+                    String minimalBuildFileConfig = createFregeSection(
+                                    fregeBuilder.version("'3.25.84'").release("'3.25alpha'").build());
+                    setupDefaultFregeProjectStructure(SIMPLE_FREGE_CODE, completionFr, minimalBuildFileConfig);
+
+                    BuildResult first = runGradleTask(COMPILE_FREGE_TASK_NAME);
+                    assertEquals(SUCCESS, first.task(":" + COMPILE_FREGE_TASK_NAME).getOutcome());
+
+                    BuildResult second = runGradleTask(COMPILE_FREGE_TASK_NAME);
+                    assertEquals(UP_TO_DATE, second.task(":" + COMPILE_FREGE_TASK_NAME).getOutcome());
+            }
+
+            @Test
+            void and_is_cached_given_cache_hit() throws Exception {
+                    String completionFr = "Completion.fr";
+                    String minimalBuildFileConfig = createFregeSection(
+                                    fregeBuilder.version("'3.25.84'").release("'3.25alpha'").build());
+                    setupDefaultFregeProjectStructure(SIMPLE_FREGE_CODE, completionFr, minimalBuildFileConfig);
+
+                    BuildResult first = runGradleTask(COMPILE_FREGE_TASK_NAME, "--build-cache");
+                    assertEquals(SUCCESS, first.task(":" + COMPILE_FREGE_TASK_NAME).getOutcome());
+
+                    String codeChange = String.join(NEW_LINE, "module ch.fhnw.thga.Completion where", NEW_LINE,
+                                    NEW_LINE,
+                                    "  frob :: Int -> (Int, String)", NEW_LINE, "  frob i = (i, \"Frege rocks\")",
+                                    NEW_LINE);
+                    setupDefaultFregeProjectStructure(codeChange, completionFr, "");
+
+                    BuildResult second = runGradleTask(COMPILE_FREGE_TASK_NAME, "--build-cache");
+                    assertEquals(SUCCESS, second.task(":" + COMPILE_FREGE_TASK_NAME).getOutcome());
+
+                    setupDefaultFregeProjectStructure(SIMPLE_FREGE_CODE, completionFr, "");
+                    BuildResult third = runGradleTask(COMPILE_FREGE_TASK_NAME, "--build-cache");
+                    assertEquals(FROM_CACHE, third.task(":" + COMPILE_FREGE_TASK_NAME).getOutcome());
+            }
+
+            @Test
+            void given_two_dependent_frege_files_in_default_source_dir_and_minimal_build_file_config()
+                            throws Exception {
+                    String completionFr = "Completion.fr";
+                    String frobFr = "Frob.fr";
+                    String frobCode = String.join(NEW_LINE, "module ch.fhnw.thga.Frob where", NEW_LINE, NEW_LINE,
+                                    "import ch.fhnw.thga.Completion (complete)", NEW_LINE,
+                                    "frob i = complete $ i + i", NEW_LINE);
+
+                    String minimalBuildFileConfig = createFregeSection(
+                                    fregeBuilder.version("'3.25.84'").release("'3.25alpha'").build());
+                    setupDefaultFregeProjectStructure(SIMPLE_FREGE_CODE, completionFr, minimalBuildFileConfig);
+                    setupDefaultFregeProjectStructure(frobCode, frobFr, "");
+
+                    BuildResult result = runGradleTask(COMPILE_FREGE_TASK_NAME);
+
+                    assertTrue(project.getTasks().getByName(COMPILE_FREGE_TASK_NAME) instanceof CompileFregeTask);
+                    assertEquals(SUCCESS, result.task(":" + COMPILE_FREGE_TASK_NAME).getOutcome());
+                    assertTrue(new File(
+                                    testProjectDir.getAbsolutePath()
+                                                    + "/build/classes/main/frege/ch/fhnw/thga/Completion.java")
+                                                                    .exists());
+                    assertTrue(new File(
+                                    testProjectDir.getAbsolutePath()
+                                                    + "/build/classes/main/frege/ch/fhnw/thga/Completion.class")
+                                                                    .exists());
+                    assertTrue(new File(testProjectDir.getAbsolutePath()
+                                    + "/build/classes/main/frege/ch/fhnw/thga/Frob.java")
+                                                    .exists());
+                    assertTrue(new File(testProjectDir.getAbsolutePath()
+                                    + "/build/classes/main/frege/ch/fhnw/thga/Frob.class")
+                                                    .exists());
+            }
+    }
+
+    @Nested
+    @TestInstance(Lifecycle.PER_CLASS)
+    @IndicativeSentencesGeneration(separator = " -> ", generator = DisplayNameGenerator.ReplaceUnderscores.class)
+    class Compile_frege_task_fails {
+            @Test
+            void given_frege_code_and_illegal_compiler_flags() throws Exception {
+                    String completionFr = "Completion.fr";
+                    String buildConfigWithIllegalCompilerFlags = createFregeSection(fregeBuilder
+                                    .version("'3.25.84'")
+                                    .release("'3.25alpha'").compilerFlags("['-make', '-bla']").build());
+                    setupDefaultFregeProjectStructure(SIMPLE_FREGE_CODE, completionFr,
+                                    buildConfigWithIllegalCompilerFlags);
+
+                    BuildResult result = runAndFailGradleTask(COMPILE_FREGE_TASK_NAME);
+
+                    assertTrue(project.getTasks().getByName(COMPILE_FREGE_TASK_NAME) instanceof CompileFregeTask);
+                    assertEquals(FAILED, result.task(":" + COMPILE_FREGE_TASK_NAME).getOutcome());
+            }
+
+            @Test
+            void given_two_dependent_frege_files_in_default_source_dir_and_without_make_compiler_flag()
+                            throws Exception {
+                    String completionFr = "Completion.fr";
+                    String frobFr = "Frob.fr";
+                    String frobCode = String.join(NEW_LINE, "module ch.fhnw.thga.Frob where", NEW_LINE, NEW_LINE,
+                                    "import ch.fhnw.thga.Completion (complete)", NEW_LINE,
+                                    "frob i = complete $ i + i", NEW_LINE);
+
+                    String minimalBuildFileConfigWithoutMake = createFregeSection(
+                                    fregeBuilder.version("'3.25.84'").release("'3.25alpha'").compilerFlags("['-v']")
+                                                    .build());
+                    setupDefaultFregeProjectStructure(SIMPLE_FREGE_CODE, completionFr,
+                                    minimalBuildFileConfigWithoutMake);
+                    setupDefaultFregeProjectStructure(frobCode, frobFr, "");
+
+                    BuildResult result = runAndFailGradleTask(COMPILE_FREGE_TASK_NAME);
+
+                    assertTrue(project.getTasks().getByName(COMPILE_FREGE_TASK_NAME) instanceof CompileFregeTask);
+                    assertEquals(FAILED, result.task(":" + COMPILE_FREGE_TASK_NAME).getOutcome());
+            }
+    }
+
+    @Nested
+    @TestInstance(Lifecycle.PER_CLASS)
+    @IndicativeSentencesGeneration(separator = " -> ", generator = DisplayNameGenerator.ReplaceUnderscores.class)
+    class Run_frege_task_works {
+            @Test
+            void given_frege_file_with_main_function_and_main_module_config() throws Exception {
+                    String fregeCode = String.join(NEW_LINE, "module ch.fhnw.thga.Main where", NEW_LINE, NEW_LINE,
+                                    "  main = do", NEW_LINE, "    println \"Frege rocks\"", NEW_LINE);
+                    String mainFr = "Main.fr";
+                    String buildFileConfig = createFregeSection(
+                                    fregeBuilder.version("'3.25.84'").release("'3.25alpha'")
+                                                    .mainModule("'ch.fhnw.thga.Main'").build());
+                    setupDefaultFregeProjectStructure(fregeCode, mainFr, buildFileConfig);
+
+                    BuildResult result = runGradleTask(RUN_FREGE_TASK_NAME);
+                    assertTrue(project.getTasks().getByName(RUN_FREGE_TASK_NAME) instanceof RunFregeTask);
+                    assertEquals(SUCCESS, result.task(":" + RUN_FREGE_TASK_NAME).getOutcome());
+                    assertTrue(result.getOutput().contains("Frege rocks"));
+            }
+
+            @Test
+            void given_frege_file_without_main_function() throws Exception {
+                    String completionFr = "Completion.fr";
+                    String buildFileConfig = createFregeSection(
+                                    fregeBuilder.version("'3.25.84'").release("'3.25alpha'")
+                                                    .mainModule("'ch.fhnw.thga.Completion'").build());
+                    setupDefaultFregeProjectStructure(SIMPLE_FREGE_CODE, completionFr, buildFileConfig);
+
+                    BuildResult result = runAndFailGradleTask(RUN_FREGE_TASK_NAME);
+                    assertTrue(project.getTasks().getByName(RUN_FREGE_TASK_NAME) instanceof RunFregeTask);
+                    assertEquals(FAILED, result.task(":" + RUN_FREGE_TASK_NAME).getOutcome());
+                    assertTrue(result.getOutput().contains("Main method not found"));
+            }
+
+            @Test
+            void given_frege_file_with_main_function_and_main_module_command_line_option() throws Exception {
+                    String fregeCode = String.join(NEW_LINE, "module ch.fhnw.thga.Main where", NEW_LINE, NEW_LINE,
+                                    "  main = do", NEW_LINE, "    println \"Frege rocks\"", NEW_LINE);
+                    String mainFr = "Main.fr";
+                    String buildFileConfig = createFregeSection(
+                                    fregeBuilder.version("'3.25.84'").release("'3.25alpha'").build());
+                    setupDefaultFregeProjectStructure(fregeCode, mainFr, buildFileConfig);
+
+                    BuildResult result = runGradleTask(RUN_FREGE_TASK_NAME, "--mainModule=ch.fhnw.thga.Main");
+                    assertTrue(project.getTasks().getByName(RUN_FREGE_TASK_NAME) instanceof RunFregeTask);
+                    assertEquals(SUCCESS, result.task(":" + RUN_FREGE_TASK_NAME).getOutcome());
+                    assertTrue(result.getOutput().contains("Frege rocks"));
+            }
+    }
+
+    @Nested
+    @TestInstance(Lifecycle.PER_CLASS)
+    @IndicativeSentencesGeneration(
+        separator = " -> ",
+        generator = DisplayNameGenerator.ReplaceUnderscores.class)
+    class Deps_frege_task_works {
+        @Test
+        void given_minimal_build_file_config() throws Exception {
+            String completionFr           = "Completion.fr";
+            String minimalBuildFileConfig = createFregeSection(
+                fregeBuilder
+                .version("'3.25.84'")
+                .release("'3.25alpha'")
+                .build());
+            setupDefaultFregeProjectStructure(
+                SIMPLE_FREGE_CODE,
+                completionFr,
+                minimalBuildFileConfig);
+
+            BuildResult result = runGradleTask(
+                DEPS_FREGE_TASK_NAME,
+                "-q",
+                String.format("--replSource=%s", completionFr));
+
+            assertTrue(
+                project.getTasks().getByName(DEPS_FREGE_TASK_NAME)
+                instanceof DependencyFregeTask);
+            assertEquals(SUCCESS, result.task(":" + DEPS_FREGE_TASK_NAME).getOutcome());
+            assertTrue(result.getOutput().contains("frege3.25.84.jar"));
+            assertFalse(result.getOutput().contains("Completion.java"));
+            assertFalse(
+                testProjectDir
+                .toPath()
+                .resolve("/build/classes/main/frege/ch/fhnw/thga/Completion.java").toFile()
+                .exists());
         }
 
-        private void writeToFile(File destination, String content) throws IOException {
-                writeFile(destination, content, false);
+
+        @Test
+        void given_build_file_config_with_dependencies() throws Exception {
+            String completionFr           = "Completion.fr";
+            String minimalBuildFileConfig = createFregeSection(
+                fregeBuilder
+                .version("'3.25.84'")
+                .release("'3.25alpha'")
+                .build());
+            setupDefaultFregeProjectStructure(
+                SIMPLE_FREGE_CODE,
+                completionFr,
+                minimalBuildFileConfig);
+            appendToFile(
+                buildFile,
+                String.join(
+                    System.lineSeparator(),
+                    "repositories {",
+                      "mavenCentral()",
+                    "}"));
+            appendToFile(
+                buildFile,
+                String.join(
+                    System.lineSeparator(),
+                    "dependencies {",
+                      "implementation group: 'org.json', name: 'json', version: '20211205'",
+                    "}"));
+
+            BuildResult result = runGradleTask(
+                DEPS_FREGE_TASK_NAME,
+                "-q",
+                String.format("--replSource=%s", completionFr));
+
+            assertTrue(
+                project.getTasks().getByName(DEPS_FREGE_TASK_NAME)
+                instanceof DependencyFregeTask);
+            assertEquals(SUCCESS, result.task(":" + DEPS_FREGE_TASK_NAME).getOutcome());
+            assertTrue(result.getOutput().contains("frege3.25.84.jar"));
+            assertTrue(result.getOutput().contains("org.json"));
+            assertFalse(result.getOutput().contains("Completion.java"));
+            assertFalse(
+                testProjectDir
+                .toPath()
+                .resolve("/build/classes/main/frege/ch/fhnw/thga/Completion.java").toFile()
+                .exists());
         }
+    }
 
-        private void appendToFile(File destination, String content) throws IOException {
-                writeFile(destination, "\n" + content, true);
+    @Nested
+    @TestInstance(Lifecycle.PER_CLASS)
+    @IndicativeSentencesGeneration(
+        separator = " -> ",
+        generator = DisplayNameGenerator.ReplaceUnderscores.class)
+    class Repl_frege_task_works
+    {
+        @Test
+        void given_minimal_build_file_config_with_replModule() throws Exception
+        {
+            String completionFr            = "Completion.fr";
+            String minimalReplModuleConfig = createFregeSection(
+                fregeBuilder
+                .version("'3.25.84'")
+                .release("'3.25alpha'")
+                .replModule(String.format("'%s'", completionFr))
+                .build());
+            setupDefaultFregeProjectStructure(
+                SIMPLE_FREGE_CODE,
+                completionFr,
+                minimalReplModuleConfig);
+
+            BuildResult result = runGradleTask(REPL_FREGE_TASK_NAME);
+
+            assertTrue(
+                project.getTasks().getByName(REPL_FREGE_TASK_NAME)
+                instanceof ReplFregeTask);
+            assertEquals(SUCCESS, result.task(":" + REPL_FREGE_TASK_NAME).getOutcome());
+            assertTrue(result.getOutput().contains("java -cp"));
+            assertTrue(result.getOutput().contains("frege3.25.84.jar"));
+            assertFalse(result.getOutput().contains("Completion.java"));
+            assertFalse(
+                testProjectDir
+                .toPath()
+                .resolve("/build/classes/main/frege/ch/fhnw/thga/Completion.java").toFile()
+                .exists());
         }
+    }
 
-        private static String createFregeSection(FregeDTO fregeDTO) {
-                return String.format("%s {\n  %s\n}", FREGE_EXTENSION_NAME, fregeDTO.toBuildFile());
+    @Nested
+    @TestInstance(Lifecycle.PER_CLASS)
+    @IndicativeSentencesGeneration(
+        separator = " -> ",
+        generator = DisplayNameGenerator.ReplaceUnderscores.class)
+    class Repl_frege_task_fails
+    {
+        @Test
+        void given_minimal_build_file_config_without_repl_module() throws Exception
+        {
+            String completionFr           = "Completion.fr";
+            String minimalBuildFileConfig = createFregeSection(
+                fregeBuilder
+                .version("'3.25.84'")
+                .release("'3.25alpha'")
+                .build());
+            setupDefaultFregeProjectStructure(
+                SIMPLE_FREGE_CODE,
+                completionFr,
+                minimalBuildFileConfig);
+
+            BuildResult result = runAndFailGradleTask(REPL_FREGE_TASK_NAME);
+
+            assertTrue(
+                project.getTasks().getByName(REPL_FREGE_TASK_NAME)
+                instanceof ReplFregeTask);
+            assertEquals(FAILED, result.task(":" + COMPILE_FREGE_TASK_NAME).getOutcome());
         }
-
-        private BuildResult runGradleTask(String... taskName) {
-                return GradleRunner.create().withProjectDir(testProjectDir).withPluginClasspath()
-                                .withArguments(taskName)
-                                .build();
-        }
-
-        private BuildResult runAndFailGradleTask(String taskName, String... args) {
-                return GradleRunner.create().withProjectDir(testProjectDir).withPluginClasspath()
-                                .withArguments(taskName)
-                                .buildAndFail();
-        }
-
-        private void setupDefaultFregeProjectStructure(String fregeCode, String fregeFileName, String buildFileConfig)
-                        throws Exception {
-                Files.createDirectories(testProjectDir.toPath().resolve(Paths.get("src", "main", "frege")));
-                File fregeFile = testProjectDir.toPath().resolve(Paths.get("src", "main", "frege", fregeFileName))
-                                .toFile();
-                writeToFile(fregeFile, fregeCode);
-                appendToFile(buildFile, buildFileConfig);
-        }
-
-        @BeforeAll
-        void beforeAll() throws Exception {
-                settingsFile = new File(testProjectDir, "settings.gradle");
-                writeToFile(settingsFile, "rootProject.name='frege-plugin'");
-                project = ProjectBuilder.builder().withProjectDir(testProjectDir).build();
-                project.getPluginManager().apply(FREGE_PLUGIN_ID);
-
-        }
-
-        @BeforeEach
-        void setup() throws Exception {
-                buildFile = new File(testProjectDir, "build.gradle");
-                writeToFile(buildFile, createPluginsSection(Stream.of(FREGE_PLUGIN_ID)));
-                fregeBuilder = FregeDTOBuilder.getInstance();
-        }
-
-        @AfterEach
-        void cleanup() {
-                testProjectDir.delete();
-        }
-
-        @Nested
-        @TestInstance(Lifecycle.PER_CLASS)
-        @IndicativeSentencesGeneration(separator = " -> ", generator = DisplayNameGenerator.ReplaceUnderscores.class)
-        class Setup_frege_task_works {
-
-                @Test
-                void given_minimal_build_file_config() throws Exception {
-                        String minimalBuildFileConfig = createFregeSection(
-                                        fregeBuilder.version("'3.25.84'").release("'3.25alpha'").build());
-                        appendToFile(buildFile, minimalBuildFileConfig);
-
-                        BuildResult result = runGradleTask(SETUP_FREGE_TASK_NAME);
-
-                        assertTrue(project.getTasks().getByName(SETUP_FREGE_TASK_NAME) instanceof SetupFregeTask);
-                        assertEquals(SUCCESS, result.task(":" + SETUP_FREGE_TASK_NAME).getOutcome());
-                        assertTrue(testProjectDir.toPath()
-                                        .resolve(Paths.get(DEFAULT_DOWNLOAD_DIRECTORY, "frege3.25.84.jar"))
-                                        .toFile().exists());
-                }
-
-                @Test
-                void given_custom_frege_compiler_download_directory_in_build_file_config() throws Exception {
-                        String buildFileConfigWithCustomDownloadDir = createFregeSection(fregeBuilder
-                                        .version("'3.25.84'")
-                                        .release("'3.25alpha'")
-                                        .compilerDownloadDir("layout.projectDirectory.dir('dist')").build());
-                        appendToFile(buildFile, buildFileConfigWithCustomDownloadDir);
-
-                        BuildResult result = runGradleTask(SETUP_FREGE_TASK_NAME);
-
-                        assertTrue(project.getTasks().getByName(SETUP_FREGE_TASK_NAME) instanceof SetupFregeTask);
-                        assertEquals(SUCCESS, result.task(":" + SETUP_FREGE_TASK_NAME).getOutcome());
-                        assertTrue(testProjectDir.toPath().resolve(Paths.get("dist", "frege3.25.84.jar")).toFile()
-                                        .exists());
-                }
-        }
-
-        @Nested
-        @TestInstance(Lifecycle.PER_CLASS)
-        @IndicativeSentencesGeneration(separator = " -> ", generator = DisplayNameGenerator.ReplaceUnderscores.class)
-        class Compile_frege_task_works {
-
-                @Test
-                void given_frege_code_in_default_source_dir_and_minimal_build_file_config() throws Exception {
-                        String completionFr = "Completion.fr";
-                        String minimalBuildFileConfig = createFregeSection(
-                                        fregeBuilder.version("'3.25.84'").release("'3.25alpha'").build());
-                        setupDefaultFregeProjectStructure(SIMPLE_FREGE_CODE, completionFr, minimalBuildFileConfig);
-
-                        BuildResult result = runGradleTask(COMPILE_FREGE_TASK_NAME);
-
-                        assertTrue(project.getTasks().getByName(COMPILE_FREGE_TASK_NAME) instanceof CompileFregeTask);
-                        assertEquals(SUCCESS, result.task(":" + COMPILE_FREGE_TASK_NAME).getOutcome());
-                        assertTrue(new File(
-                                        testProjectDir.getAbsolutePath()
-                                                        + "/build/classes/main/frege/ch/fhnw/thga/Completion.java")
-                                                                        .exists());
-                        assertTrue(new File(
-                                        testProjectDir.getAbsolutePath()
-                                                        + "/build/classes/main/frege/ch/fhnw/thga/Completion.class")
-                                                                        .exists());
-                }
-
-                @Test
-                void given_frege_code_and_many_compiler_flags() throws Exception {
-                        String completionFr = "Completion.fr";
-                        String buildConfigWithCompilerFlags = createFregeSection(fregeBuilder.version("'3.25.84'")
-                                        .release("'3.25alpha'").compilerFlags("['-v', '-make', '-O', '-hints']")
-                                        .build());
-                        setupDefaultFregeProjectStructure(SIMPLE_FREGE_CODE, completionFr,
-                                        buildConfigWithCompilerFlags);
-
-                        BuildResult result = runGradleTask(COMPILE_FREGE_TASK_NAME);
-
-                        assertTrue(project.getTasks().getByName(COMPILE_FREGE_TASK_NAME) instanceof CompileFregeTask);
-                        assertEquals(SUCCESS, result.task(":" + COMPILE_FREGE_TASK_NAME).getOutcome());
-                        assertTrue(new File(
-                                        testProjectDir.getAbsolutePath()
-                                                        + "/build/classes/main/frege/ch/fhnw/thga/Completion.java")
-                                                                        .exists());
-                        assertTrue(new File(
-                                        testProjectDir.getAbsolutePath()
-                                                        + "/build/classes/main/frege/ch/fhnw/thga/Completion.class")
-                                                                        .exists());
-                }
-
-                @Test
-                void given_frege_code_in_custom_source_dir_and_custom_output_dir_and_minimal_build_file_config()
-                                throws Exception {
-                        Path customMainSourceDir = testProjectDir.toPath().resolve(Paths.get("src", "frege"));
-                        Files.createDirectories(customMainSourceDir);
-                        File completionFr = customMainSourceDir.resolve("Completion.fr").toFile();
-                        writeToFile(completionFr, SIMPLE_FREGE_CODE);
-                        String minimalBuildFileConfig = createFregeSection(
-                                        fregeBuilder.version("'3.25.84'").release("'3.25alpha'")
-                                                        .mainSourceDir("layout.projectDirectory.dir('src/frege')")
-                                                        .outputDir("layout.buildDirectory.dir('frege')").build());
-                        appendToFile(buildFile, minimalBuildFileConfig);
-
-                        BuildResult result = runGradleTask(COMPILE_FREGE_TASK_NAME);
-
-                        assertTrue(project.getTasks().getByName(COMPILE_FREGE_TASK_NAME) instanceof CompileFregeTask);
-                        assertEquals(SUCCESS, result.task(":" + COMPILE_FREGE_TASK_NAME).getOutcome());
-                        assertTrue(
-                                        new File(testProjectDir.getAbsolutePath()
-                                                        + "/build/frege/ch/fhnw/thga/Completion.java").exists());
-                        assertTrue(
-                                        new File(testProjectDir.getAbsolutePath()
-                                                        + "/build/frege/ch/fhnw/thga/Completion.class").exists());
-                }
-
-                @Test
-                void and_is_up_to_date_given_no_code_changes() throws Exception {
-                        String completionFr = "Completion.fr";
-                        String minimalBuildFileConfig = createFregeSection(
-                                        fregeBuilder.version("'3.25.84'").release("'3.25alpha'").build());
-                        setupDefaultFregeProjectStructure(SIMPLE_FREGE_CODE, completionFr, minimalBuildFileConfig);
-
-                        BuildResult first = runGradleTask(COMPILE_FREGE_TASK_NAME);
-                        assertEquals(SUCCESS, first.task(":" + COMPILE_FREGE_TASK_NAME).getOutcome());
-
-                        BuildResult second = runGradleTask(COMPILE_FREGE_TASK_NAME);
-                        assertEquals(UP_TO_DATE, second.task(":" + COMPILE_FREGE_TASK_NAME).getOutcome());
-                }
-
-                @Test
-                void and_is_cached_given_cache_hit() throws Exception {
-                        String completionFr = "Completion.fr";
-                        String minimalBuildFileConfig = createFregeSection(
-                                        fregeBuilder.version("'3.25.84'").release("'3.25alpha'").build());
-                        setupDefaultFregeProjectStructure(SIMPLE_FREGE_CODE, completionFr, minimalBuildFileConfig);
-
-                        BuildResult first = runGradleTask(COMPILE_FREGE_TASK_NAME, "--build-cache");
-                        assertEquals(SUCCESS, first.task(":" + COMPILE_FREGE_TASK_NAME).getOutcome());
-
-                        String codeChange = String.join(NEW_LINE, "module ch.fhnw.thga.Completion where", NEW_LINE,
-                                        NEW_LINE,
-                                        "  frob :: Int -> (Int, String)", NEW_LINE, "  frob i = (i, \"Frege rocks\")",
-                                        NEW_LINE);
-                        setupDefaultFregeProjectStructure(codeChange, completionFr, "");
-
-                        BuildResult second = runGradleTask(COMPILE_FREGE_TASK_NAME, "--build-cache");
-                        assertEquals(SUCCESS, second.task(":" + COMPILE_FREGE_TASK_NAME).getOutcome());
-
-                        setupDefaultFregeProjectStructure(SIMPLE_FREGE_CODE, completionFr, "");
-                        BuildResult third = runGradleTask(COMPILE_FREGE_TASK_NAME, "--build-cache");
-                        assertEquals(FROM_CACHE, third.task(":" + COMPILE_FREGE_TASK_NAME).getOutcome());
-                }
-
-                @Test
-                void given_two_dependent_frege_files_in_default_source_dir_and_minimal_build_file_config()
-                                throws Exception {
-                        String completionFr = "Completion.fr";
-                        String frobFr = "Frob.fr";
-                        String frobCode = String.join(NEW_LINE, "module ch.fhnw.thga.Frob where", NEW_LINE, NEW_LINE,
-                                        "import ch.fhnw.thga.Completion (complete)", NEW_LINE,
-                                        "frob i = complete $ i + i", NEW_LINE);
-
-                        String minimalBuildFileConfig = createFregeSection(
-                                        fregeBuilder.version("'3.25.84'").release("'3.25alpha'").build());
-                        setupDefaultFregeProjectStructure(SIMPLE_FREGE_CODE, completionFr, minimalBuildFileConfig);
-                        setupDefaultFregeProjectStructure(frobCode, frobFr, "");
-
-                        BuildResult result = runGradleTask(COMPILE_FREGE_TASK_NAME);
-
-                        assertTrue(project.getTasks().getByName(COMPILE_FREGE_TASK_NAME) instanceof CompileFregeTask);
-                        assertEquals(SUCCESS, result.task(":" + COMPILE_FREGE_TASK_NAME).getOutcome());
-                        assertTrue(new File(
-                                        testProjectDir.getAbsolutePath()
-                                                        + "/build/classes/main/frege/ch/fhnw/thga/Completion.java")
-                                                                        .exists());
-                        assertTrue(new File(
-                                        testProjectDir.getAbsolutePath()
-                                                        + "/build/classes/main/frege/ch/fhnw/thga/Completion.class")
-                                                                        .exists());
-                        assertTrue(new File(testProjectDir.getAbsolutePath()
-                                        + "/build/classes/main/frege/ch/fhnw/thga/Frob.java")
-                                                        .exists());
-                        assertTrue(new File(testProjectDir.getAbsolutePath()
-                                        + "/build/classes/main/frege/ch/fhnw/thga/Frob.class")
-                                                        .exists());
-                }
-        }
-
-        @Nested
-        @TestInstance(Lifecycle.PER_CLASS)
-        @IndicativeSentencesGeneration(separator = " -> ", generator = DisplayNameGenerator.ReplaceUnderscores.class)
-        class Compile_frege_task_fails {
-                @Test
-                void given_frege_code_and_illegal_compiler_flags() throws Exception {
-                        String completionFr = "Completion.fr";
-                        String buildConfigWithIllegalCompilerFlags = createFregeSection(fregeBuilder
-                                        .version("'3.25.84'")
-                                        .release("'3.25alpha'").compilerFlags("['-make', '-bla']").build());
-                        setupDefaultFregeProjectStructure(SIMPLE_FREGE_CODE, completionFr,
-                                        buildConfigWithIllegalCompilerFlags);
-
-                        BuildResult result = runAndFailGradleTask(COMPILE_FREGE_TASK_NAME);
-
-                        assertTrue(project.getTasks().getByName(COMPILE_FREGE_TASK_NAME) instanceof CompileFregeTask);
-                        assertEquals(FAILED, result.task(":" + COMPILE_FREGE_TASK_NAME).getOutcome());
-                }
-
-                @Test
-                void given_two_dependent_frege_files_in_default_source_dir_and_without_make_compiler_flag()
-                                throws Exception {
-                        String completionFr = "Completion.fr";
-                        String frobFr = "Frob.fr";
-                        String frobCode = String.join(NEW_LINE, "module ch.fhnw.thga.Frob where", NEW_LINE, NEW_LINE,
-                                        "import ch.fhnw.thga.Completion (complete)", NEW_LINE,
-                                        "frob i = complete $ i + i", NEW_LINE);
-
-                        String minimalBuildFileConfigWithoutMake = createFregeSection(
-                                        fregeBuilder.version("'3.25.84'").release("'3.25alpha'").compilerFlags("['-v']")
-                                                        .build());
-                        setupDefaultFregeProjectStructure(SIMPLE_FREGE_CODE, completionFr,
-                                        minimalBuildFileConfigWithoutMake);
-                        setupDefaultFregeProjectStructure(frobCode, frobFr, "");
-
-                        BuildResult result = runAndFailGradleTask(COMPILE_FREGE_TASK_NAME);
-
-                        assertTrue(project.getTasks().getByName(COMPILE_FREGE_TASK_NAME) instanceof CompileFregeTask);
-                        assertEquals(FAILED, result.task(":" + COMPILE_FREGE_TASK_NAME).getOutcome());
-                }
-        }
-
-        @Nested
-        @TestInstance(Lifecycle.PER_CLASS)
-        @IndicativeSentencesGeneration(separator = " -> ", generator = DisplayNameGenerator.ReplaceUnderscores.class)
-        class Run_frege_task_works {
-                @Test
-                void given_frege_file_with_main_function_and_main_module_config() throws Exception {
-                        String fregeCode = String.join(NEW_LINE, "module ch.fhnw.thga.Main where", NEW_LINE, NEW_LINE,
-                                        "  main = do", NEW_LINE, "    println \"Frege rocks\"", NEW_LINE);
-                        String mainFr = "Main.fr";
-                        String buildFileConfig = createFregeSection(
-                                        fregeBuilder.version("'3.25.84'").release("'3.25alpha'")
-                                                        .mainModule("'ch.fhnw.thga.Main'").build());
-                        setupDefaultFregeProjectStructure(fregeCode, mainFr, buildFileConfig);
-
-                        BuildResult result = runGradleTask(RUN_FREGE_TASK_NAME);
-                        assertTrue(project.getTasks().getByName(RUN_FREGE_TASK_NAME) instanceof RunFregeTask);
-                        assertEquals(SUCCESS, result.task(":" + RUN_FREGE_TASK_NAME).getOutcome());
-                        assertTrue(result.getOutput().contains("Frege rocks"));
-                }
-
-                @Test
-                void given_frege_file_without_main_function() throws Exception {
-                        String completionFr = "Completion.fr";
-                        String buildFileConfig = createFregeSection(
-                                        fregeBuilder.version("'3.25.84'").release("'3.25alpha'")
-                                                        .mainModule("'ch.fhnw.thga.Completion'").build());
-                        setupDefaultFregeProjectStructure(SIMPLE_FREGE_CODE, completionFr, buildFileConfig);
-
-                        BuildResult result = runAndFailGradleTask(RUN_FREGE_TASK_NAME);
-                        assertTrue(project.getTasks().getByName(RUN_FREGE_TASK_NAME) instanceof RunFregeTask);
-                        assertEquals(FAILED, result.task(":" + RUN_FREGE_TASK_NAME).getOutcome());
-                        assertTrue(result.getOutput().contains("Main method not found"));
-                }
-
-                @Test
-                void given_frege_file_with_main_function_and_main_module_command_line_option() throws Exception {
-                        String fregeCode = String.join(NEW_LINE, "module ch.fhnw.thga.Main where", NEW_LINE, NEW_LINE,
-                                        "  main = do", NEW_LINE, "    println \"Frege rocks\"", NEW_LINE);
-                        String mainFr = "Main.fr";
-                        String buildFileConfig = createFregeSection(
-                                        fregeBuilder.version("'3.25.84'").release("'3.25alpha'").build());
-                        setupDefaultFregeProjectStructure(fregeCode, mainFr, buildFileConfig);
-
-                        BuildResult result = runGradleTask(RUN_FREGE_TASK_NAME, "--mainModule=ch.fhnw.thga.Main");
-                        assertTrue(project.getTasks().getByName(RUN_FREGE_TASK_NAME) instanceof RunFregeTask);
-                        assertEquals(SUCCESS, result.task(":" + RUN_FREGE_TASK_NAME).getOutcome());
-                        assertTrue(result.getOutput().contains("Frege rocks"));
-                }
-        }
-
-        @Nested
-        @TestInstance(Lifecycle.PER_CLASS)
-        @IndicativeSentencesGeneration(separator = " -> ", generator = DisplayNameGenerator.ReplaceUnderscores.class)
-        class Deps_frege_task_works {
-                @Test
-                void given_minimal_build_file_config() throws Exception {
-                        String completionFr = "Completion.fr";
-                        String minimalBuildFileConfig = createFregeSection(
-                                        fregeBuilder.version("'3.25.84'").release("'3.25alpha'").build());
-                        setupDefaultFregeProjectStructure(SIMPLE_FREGE_CODE, completionFr, minimalBuildFileConfig);
-
-                        BuildResult result = runGradleTask(DEPS_FREGE_TASK_NAME, "-q");
-                        assertTrue(project.getTasks().getByName(DEPS_FREGE_TASK_NAME) instanceof DependencyFregeTask);
-                        assertEquals(SUCCESS, result.task(":" + DEPS_FREGE_TASK_NAME).getOutcome());
-                        assertTrue(result.getOutput().contains("frege3.25.84.jar"));
-                }
-
-                @Test
-                void given_build_file_config_with_dependencies() throws Exception {
-                        String minimalBuildFileConfig = createFregeSection(
-                                        fregeBuilder.version("'3.25.84'").release("'3.25alpha'").build());
-                        String completionFr = "Completion.fr";
-                        setupDefaultFregeProjectStructure(SIMPLE_FREGE_CODE, completionFr, minimalBuildFileConfig);
-                        appendToFile(buildFile, String.join("\n", "repositories {", "mavenCentral()", "}"));
-                        appendToFile(buildFile, String.join("\n", "dependencies {",
-                                        "implementation group: 'org.json', name: 'json', version: '20211205'", "}"));
-
-                        BuildResult result = runGradleTask(DEPS_FREGE_TASK_NAME, "-q");
-                        assertTrue(project.getTasks().getByName(DEPS_FREGE_TASK_NAME) instanceof DependencyFregeTask);
-                        assertEquals(SUCCESS, result.task(":" + DEPS_FREGE_TASK_NAME).getOutcome());
-                        assertTrue(result.getOutput().contains("frege3.25.84.jar"));
-                        assertTrue(result.getOutput().contains("org.json"));
-                }
-        }
-
-        @Nested
-        @TestInstance(Lifecycle.PER_CLASS)
-        @IndicativeSentencesGeneration(separator = " -> ", generator = DisplayNameGenerator.ReplaceUnderscores.class)
-        class Repl_frege_task_works {
-                @Test
-                void given_minimal_build_file_config() throws Exception {
-                        String completionFr = "Completion.fr";
-                        String minimalBuildFileConfig = createFregeSection(
-                                        fregeBuilder.version("'3.25.84'").release("'3.25alpha'").build());
-                        setupDefaultFregeProjectStructure(SIMPLE_FREGE_CODE, completionFr, minimalBuildFileConfig);
-
-                        BuildResult result = runGradleTask(REPL_FREGE_TASK_NAME, "-q");
-                        assertTrue(project.getTasks().getByName(REPL_FREGE_TASK_NAME) instanceof ReplFregeTask);
-                        assertEquals(SUCCESS, result.task(":" + REPL_FREGE_TASK_NAME).getOutcome());
-                        assertTrue(result.getOutput().contains("java -cp"));
-                        assertTrue(result.getOutput().contains("frege3.25.84.jar"));
-                }
-        }
+    }
 }

--- a/src/functionalTest/java/ch/fhnw/thga/gradleplugins/FregePluginFunctionalTest.java
+++ b/src/functionalTest/java/ch/fhnw/thga/gradleplugins/FregePluginFunctionalTest.java
@@ -500,7 +500,7 @@ public class FregePluginFunctionalTest {
                 fregeBuilder
                 .version("'3.25.84'")
                 .release("'3.25alpha'")
-                .replModule(String.format("'%s'", completionFr))
+                .replSource(String.format("'%s'", completionFr))
                 .build());
             setupDefaultFregeProjectStructure(
                 SIMPLE_FREGE_CODE,

--- a/src/functionalTest/java/ch/fhnw/thga/gradleplugins/FregePluginFunctionalTest.java
+++ b/src/functionalTest/java/ch/fhnw/thga/gradleplugins/FregePluginFunctionalTest.java
@@ -400,9 +400,10 @@ public class FregePluginFunctionalTest {
         class Deps_frege_task_works {
                 @Test
                 void given_minimal_build_file_config() throws Exception {
+                        String completionFr = "Completion.fr";
                         String minimalBuildFileConfig = createFregeSection(
                                         fregeBuilder.version("'3.25.84'").release("'3.25alpha'").build());
-                        appendToFile(buildFile, minimalBuildFileConfig);
+                        setupDefaultFregeProjectStructure(SIMPLE_FREGE_CODE, completionFr, minimalBuildFileConfig);
 
                         BuildResult result = runGradleTask(DEPS_FREGE_TASK_NAME, "-q");
                         assertTrue(project.getTasks().getByName(DEPS_FREGE_TASK_NAME) instanceof DependencyFregeTask);
@@ -414,10 +415,12 @@ public class FregePluginFunctionalTest {
                 void given_build_file_config_with_dependencies() throws Exception {
                         String minimalBuildFileConfig = createFregeSection(
                                         fregeBuilder.version("'3.25.84'").release("'3.25alpha'").build());
-                        appendToFile(buildFile, minimalBuildFileConfig);
+                        String completionFr = "Completion.fr";
+                        setupDefaultFregeProjectStructure(SIMPLE_FREGE_CODE, completionFr, minimalBuildFileConfig);
                         appendToFile(buildFile, String.join("\n", "repositories {", "mavenCentral()", "}"));
                         appendToFile(buildFile, String.join("\n", "dependencies {",
                                         "implementation group: 'org.json', name: 'json', version: '20211205'", "}"));
+
                         BuildResult result = runGradleTask(DEPS_FREGE_TASK_NAME, "-q");
                         assertTrue(project.getTasks().getByName(DEPS_FREGE_TASK_NAME) instanceof DependencyFregeTask);
                         assertEquals(SUCCESS, result.task(":" + DEPS_FREGE_TASK_NAME).getOutcome());
@@ -432,9 +435,10 @@ public class FregePluginFunctionalTest {
         class Repl_frege_task_works {
                 @Test
                 void given_minimal_build_file_config() throws Exception {
+                        String completionFr = "Completion.fr";
                         String minimalBuildFileConfig = createFregeSection(
                                         fregeBuilder.version("'3.25.84'").release("'3.25alpha'").build());
-                        appendToFile(buildFile, minimalBuildFileConfig);
+                        setupDefaultFregeProjectStructure(SIMPLE_FREGE_CODE, completionFr, minimalBuildFileConfig);
 
                         BuildResult result = runGradleTask(REPL_FREGE_TASK_NAME, "-q");
                         assertTrue(project.getTasks().getByName(REPL_FREGE_TASK_NAME) instanceof ReplFregeTask);

--- a/src/main/java/ch/fhnw/thga/gradleplugins/CompileFregeTask.java
+++ b/src/main/java/ch/fhnw/thga/gradleplugins/CompileFregeTask.java
@@ -32,7 +32,9 @@ import org.gradle.api.tasks.TaskAction;
 @CacheableTask
 public abstract class CompileFregeTask extends DefaultTask {
     private final JavaExec javaExec;
-    private static final BiFunction<String, Directory, FileTree> excludeReplSourceFile =
+    private static final String FREGE_FILES_GLOB_PATTERN          = "**/*.fr";
+    private static final BiFunction<String, Directory, FileTree>
+                                            excludeReplSourceFile =
         (String replSource,
         Directory srcDir) ->
     {
@@ -89,6 +91,7 @@ public abstract class CompileFregeTask extends DefaultTask {
     @Internal
     public final Provider<List<String>> getSourceFiles() {
         return getSourceFileTree()
+            .map(tree -> tree.matching(pattern -> pattern.include(FREGE_FILES_GLOB_PATTERN)))
             .map(tree -> tree.getFiles().stream()
             .map(file -> file.getAbsolutePath())
             .collect(Collectors.toList())

--- a/src/main/java/ch/fhnw/thga/gradleplugins/FregeExtension.java
+++ b/src/main/java/ch/fhnw/thga/gradleplugins/FregeExtension.java
@@ -10,9 +10,9 @@ import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
 
 public abstract class FregeExtension {
-    public static final String DEFAULT_DOWNLOAD_DIRECTORY = "lib";
-    public static final String DEFAULT_RELATIVE_OUTPUT_DIR = "classes/main/frege";
-    public static final String DEFAULT_RELATIVE_SOURCE_DIR = "src/main/frege";
+    public static final String DEFAULT_DOWNLOAD_DIRECTORY   = "lib";
+    public static final String DEFAULT_RELATIVE_OUTPUT_DIR  = "classes/main/frege";
+    public static final String DEFAULT_RELATIVE_SOURCE_DIR  = "src/main/frege";
     public static final List<String> DEFAULT_COMPILER_FLAGS = List.of("-O", "-make");
 
     public abstract Property<String> getVersion();
@@ -29,11 +29,19 @@ public abstract class FregeExtension {
 
     public abstract ListProperty<String> getCompilerFlags();
 
+    public abstract Property<String> getReplModule();
+
     @Inject
     public FregeExtension(ProjectLayout projectLayout) {
-        getCompilerDownloadDir().convention(projectLayout.getProjectDirectory().dir(DEFAULT_DOWNLOAD_DIRECTORY));
-        getMainSourceDir().convention(projectLayout.getProjectDirectory().dir(DEFAULT_RELATIVE_SOURCE_DIR));
-        getOutputDir().convention(projectLayout.getBuildDirectory().dir(DEFAULT_RELATIVE_OUTPUT_DIR));
+        getCompilerDownloadDir()
+        .convention(projectLayout.getProjectDirectory().dir(DEFAULT_DOWNLOAD_DIRECTORY));
+
+        getMainSourceDir()
+        .convention(projectLayout.getProjectDirectory().dir(DEFAULT_RELATIVE_SOURCE_DIR));
+
+        getOutputDir()
+        .convention(projectLayout.getBuildDirectory().dir(DEFAULT_RELATIVE_OUTPUT_DIR));
+
         getCompilerFlags().convention(DEFAULT_COMPILER_FLAGS);
     }
 }

--- a/src/main/java/ch/fhnw/thga/gradleplugins/FregeExtension.java
+++ b/src/main/java/ch/fhnw/thga/gradleplugins/FregeExtension.java
@@ -29,7 +29,7 @@ public abstract class FregeExtension {
 
     public abstract ListProperty<String> getCompilerFlags();
 
-    public abstract Property<String> getReplModule();
+    public abstract Property<String> getReplSource();
 
     @Inject
     public FregeExtension(ProjectLayout projectLayout) {

--- a/src/main/java/ch/fhnw/thga/gradleplugins/FregePlugin.java
+++ b/src/main/java/ch/fhnw/thga/gradleplugins/FregePlugin.java
@@ -5,19 +5,20 @@ import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.RegularFile;
+import org.gradle.api.file.SourceDirectorySet;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.TaskProvider;
 
 import ch.fhnw.thga.gradleplugins.internal.DependencyFregeTask;
 
 public class FregePlugin implements Plugin<Project> {
-    public static final String SETUP_FREGE_TASK_NAME = "setupFrege";
-    public static final String COMPILE_FREGE_TASK_NAME = "compileFrege";
-    public static final String RUN_FREGE_TASK_NAME = "runFrege";
-    public static final String REPL_FREGE_TASK_NAME = "replFrege";
-    public static final String DEPS_FREGE_TASK_NAME = "depsFrege";
-    public static final String FREGE_PLUGIN_ID = "ch.fhnw.thga.frege";
-    public static final String FREGE_EXTENSION_NAME = "frege";
+    public static final String SETUP_FREGE_TASK_NAME      = "setupFrege";
+    public static final String COMPILE_FREGE_TASK_NAME    = "compileFrege";
+    public static final String RUN_FREGE_TASK_NAME        = "runFrege";
+    public static final String REPL_FREGE_TASK_NAME       = "replFrege";
+    public static final String DEPS_FREGE_TASK_NAME       = "depsFrege";
+    public static final String FREGE_PLUGIN_ID            = "ch.fhnw.thga.frege";
+    public static final String FREGE_EXTENSION_NAME       = "frege";
     public static final String FREGE_IMPLEMENTATION_SCOPE = "implementation";
 
     private FileCollection setupClasspath(Project project, Configuration dependencies,
@@ -32,7 +33,8 @@ public class FregePlugin implements Plugin<Project> {
     @Override
     public void apply(Project project) {
         Configuration implementation = project.getConfigurations().create(FREGE_IMPLEMENTATION_SCOPE);
-        FregeExtension extension = project.getExtensions().create(FREGE_EXTENSION_NAME, FregeExtension.class);
+        FregeExtension extension     = project.getExtensions().create(FREGE_EXTENSION_NAME, FregeExtension.class);
+
         TaskProvider<SetupFregeTask> setupFregeCompilerTask = project.getTasks().register(SETUP_FREGE_TASK_NAME,
                 SetupFregeTask.class, task -> {
                     task.getVersion().set(extension.getVersion());
@@ -49,6 +51,7 @@ public class FregePlugin implements Plugin<Project> {
                     task.getFregeCompilerFlags().set(extension.getCompilerFlags());
                     task.getFregeDependencies().set(implementation.getAsPath());
                 });
+
         project.getTasks().register(RUN_FREGE_TASK_NAME, RunFregeTask.class, task -> {
             task.dependsOn(compileFregeTask);
             task.getFregeCompilerJar().set(setupFregeCompilerTask.get().getFregeCompilerOutputPath());
@@ -56,16 +59,19 @@ public class FregePlugin implements Plugin<Project> {
             task.getMainModule().set(extension.getMainModule());
             task.getFregeDependencies().set(implementation.getAsPath());
         });
+
         project.getTasks().register(DEPS_FREGE_TASK_NAME,
                 DependencyFregeTask.class, task -> {
-                    task.dependsOn(setupFregeCompilerTask);
+                    task.dependsOn(compileFregeTask);
                     task.getClasspath().setFrom(setupClasspath(project, implementation,
-                            setupFregeCompilerTask.get().getFregeCompilerOutputPath()));
+                            setupFregeCompilerTask.get().getFregeCompilerOutputPath()), extension.getOutputDir().get());
                 });
+
         project.getTasks().register(REPL_FREGE_TASK_NAME, ReplFregeTask.class, task -> {
-            task.dependsOn(setupFregeCompilerTask);
-            task.getFregeClasspath().setFrom(setupClasspath(project, implementation,
-                    setupFregeCompilerTask.get().getFregeCompilerOutputPath()));
+            task.dependsOn(compileFregeTask);
+            task.getFregeClasspath()
+                .setFrom(setupClasspath(project, implementation, setupFregeCompilerTask.get().getFregeCompilerOutputPath())
+                , extension.getOutputDir().get());
         });
     }
 }

--- a/src/main/java/ch/fhnw/thga/gradleplugins/FregePlugin.java
+++ b/src/main/java/ch/fhnw/thga/gradleplugins/FregePlugin.java
@@ -97,7 +97,7 @@ public class FregePlugin implements Plugin<Project>
             ReplFregeTask.class,
             task ->
             {
-                task.getReplSource().set(extension.getReplModule());
+                task.getReplSource().set(extension.getReplSource());
                 task.dependsOn(compileFregeTask.map(
                     compileTask ->
                     {

--- a/src/main/java/ch/fhnw/thga/gradleplugins/ReplFregeTask.java
+++ b/src/main/java/ch/fhnw/thga/gradleplugins/ReplFregeTask.java
@@ -1,19 +1,37 @@
 package ch.fhnw.thga.gradleplugins;
 
 import org.gradle.api.DefaultTask;
-import org.gradle.api.file.ConfigurableFileCollection;
-import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputDirectory;
+import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.TaskAction;
 
 public abstract class ReplFregeTask extends DefaultTask {
     public static final String REPL_MAIN_CLASS = "frege.repl.FregeRepl";
 
-    @InputFiles
-    public abstract ConfigurableFileCollection getFregeClasspath();
+    @InputFile
+    public abstract RegularFileProperty getFregeCompilerJar();
+
+    @Input
+    public abstract Property<String> getFregeDependencies();
+
+    @InputDirectory
+    public abstract DirectoryProperty getFregeOutputDir();
 
     @TaskAction
     public void printStartFregeReplCommand() {
         System.out.println("Execute the following command to start the Frege Repl:");
-        System.out.println(String.format("java -cp %s %s", getFregeClasspath().getAsPath(), REPL_MAIN_CLASS));
+        System.out.println(String.format(
+            "java -cp %s %s",
+            SharedTaskLogic.setupClasspath(
+                getProject(),
+                getFregeDependencies(),
+                getFregeCompilerJar(),
+                getFregeOutputDir())
+            .get().getAsPath(),
+            REPL_MAIN_CLASS));
     }
 }

--- a/src/main/java/ch/fhnw/thga/gradleplugins/ReplFregeTask.java
+++ b/src/main/java/ch/fhnw/thga/gradleplugins/ReplFregeTask.java
@@ -8,6 +8,7 @@ import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputDirectory;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.tasks.options.Option;
 
 public abstract class ReplFregeTask extends DefaultTask {
     public static final String REPL_MAIN_CLASS = "frege.repl.FregeRepl";
@@ -20,6 +21,11 @@ public abstract class ReplFregeTask extends DefaultTask {
 
     @InputDirectory
     public abstract DirectoryProperty getFregeOutputDir();
+
+    @Input
+    @Option(option     = "replSource",
+           description = "The filename which you want to load into the repl, e.g. 'myFregeFile.fr'")
+    public abstract Property<String> getReplSource();
 
     @TaskAction
     public void printStartFregeReplCommand() {

--- a/src/main/java/ch/fhnw/thga/gradleplugins/SetupFregeTask.java
+++ b/src/main/java/ch/fhnw/thga/gradleplugins/SetupFregeTask.java
@@ -21,9 +21,10 @@ import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
 
 public abstract class SetupFregeTask extends DefaultTask {
-    public static final Logger LOGGER = Logging.getLogger(SetupFregeTask.class);
+    public static final Logger LOGGER                   = Logging.getLogger(SetupFregeTask.class);
 
-    private static final String FREGE_GITHUB_URL_PREFIX = "https://github.com/Frege/frege/releases/download";
+    private static final String FREGE_GITHUB_URL_PREFIX =
+                                               "https://github.com/Frege/frege/releases/download";
 
     @Input
     public abstract Property<String> getVersion();

--- a/src/main/java/ch/fhnw/thga/gradleplugins/SharedTaskLogic.java
+++ b/src/main/java/ch/fhnw/thga/gradleplugins/SharedTaskLogic.java
@@ -1,0 +1,22 @@
+package ch.fhnw.thga.gradleplugins;
+
+import org.gradle.api.Project;
+import org.gradle.api.file.FileCollection;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.provider.Property;
+
+public final class SharedTaskLogic {
+    private SharedTaskLogic() {};
+
+    public static final Provider<FileCollection> setupClasspath(
+        Project project,
+        Property<String> dependencies,
+        Object... paths)
+    {
+        return dependencies.map(depsClasspath ->
+        {
+            return depsClasspath.isEmpty() ? project.files(paths)
+                                           : project.files(depsClasspath, paths);
+        });
+    }
+}

--- a/src/main/java/ch/fhnw/thga/gradleplugins/internal/DependencyFregeTask.java
+++ b/src/main/java/ch/fhnw/thga/gradleplugins/internal/DependencyFregeTask.java
@@ -1,16 +1,35 @@
 package ch.fhnw.thga.gradleplugins.internal;
 
 import org.gradle.api.DefaultTask;
-import org.gradle.api.file.ConfigurableFileCollection;
-import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputDirectory;
+import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.TaskAction;
 
+import ch.fhnw.thga.gradleplugins.SharedTaskLogic;
+
 public abstract class DependencyFregeTask extends DefaultTask {
-    @InputFiles
-    public abstract ConfigurableFileCollection getClasspath();
+    @InputFile
+    public abstract RegularFileProperty getFregeCompilerJar();
+
+    @Input
+    public abstract Property<String> getFregeDependencies();
+
+    @InputDirectory
+    public abstract DirectoryProperty getFregeOutputDir();
+
 
     @TaskAction
     public void fregeDependencies() {
-        System.out.println(getClasspath().getAsPath());
+        System.out.println(
+            SharedTaskLogic.setupClasspath(
+                getProject(),
+                getFregeDependencies(),
+                getFregeCompilerJar(),
+                getFregeOutputDir())
+            .get().getAsPath());
     }
 }

--- a/src/main/java/ch/fhnw/thga/gradleplugins/internal/DependencyFregeTask.java
+++ b/src/main/java/ch/fhnw/thga/gradleplugins/internal/DependencyFregeTask.java
@@ -8,6 +8,7 @@ import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputDirectory;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.tasks.options.Option;
 
 import ch.fhnw.thga.gradleplugins.SharedTaskLogic;
 
@@ -20,6 +21,11 @@ public abstract class DependencyFregeTask extends DefaultTask {
 
     @InputDirectory
     public abstract DirectoryProperty getFregeOutputDir();
+
+    @Input
+    @Option(option     = "replSource",
+           description = "The filename which you want to load into the repl, e.g. 'myFregeFile.fr'")
+    public abstract Property<String> getReplSource();
 
 
     @TaskAction

--- a/src/test/java/ch/fhnw/thga/gradleplugins/Builder.java
+++ b/src/test/java/ch/fhnw/thga/gradleplugins/Builder.java
@@ -15,7 +15,7 @@ public interface Builder {
 
     Builder compilerFlags(String compilerFlags);
 
-    Builder replModule(String replModule);
+    Builder replSource(String replSource);
 
     FregeDTO build();
 }

--- a/src/test/java/ch/fhnw/thga/gradleplugins/Builder.java
+++ b/src/test/java/ch/fhnw/thga/gradleplugins/Builder.java
@@ -15,5 +15,7 @@ public interface Builder {
 
     Builder compilerFlags(String compilerFlags);
 
+    Builder replModule(String replModule);
+
     FregeDTO build();
 }

--- a/src/test/java/ch/fhnw/thga/gradleplugins/FregeDTO.java
+++ b/src/test/java/ch/fhnw/thga/gradleplugins/FregeDTO.java
@@ -14,9 +14,17 @@ public class FregeDTO {
     public final String outputDir;
     public final String mainModule;
     public final String compilerFlags;
+    public final String replModule;
 
-    public FregeDTO(String version, String release, String compilerDownloadDir, String mainSourceDir,
-            String outputDir, String mainModule, String compilerFlags) {
+    public FregeDTO(
+        String version,
+        String release,
+        String compilerDownloadDir,
+        String mainSourceDir,
+        String outputDir,
+        String mainModule,
+        String compilerFlags,
+        String replModule) {
         this.version = version;
         this.release = release;
         this.compilerDownloadDir = compilerDownloadDir;
@@ -24,6 +32,7 @@ public class FregeDTO {
         this.outputDir = outputDir;
         this.mainModule = mainModule;
         this.compilerFlags = compilerFlags;
+        this.replModule = replModule;
     }
 
     public String getVersion() {
@@ -54,6 +63,10 @@ public class FregeDTO {
         return compilerFlags;
     }
 
+    public String getReplModule() {
+        return replModule;
+    }
+
     private String getFieldValue(Field field) {
         try {
             return field.get(this).toString();
@@ -67,7 +80,9 @@ public class FregeDTO {
             return FregeDTO.class.getField(fieldName);
         } catch (NoSuchFieldException e) {
             throw new RuntimeException(
-                    String.format("Field %s not found in class %s", e.getMessage(), FregeDTO.class.getName()),
+                    String.format(
+                        "Field %s not found in class %s",
+                        e.getMessage(), FregeDTO.class.getName()),
                     e.getCause());
         }
     }
@@ -81,7 +96,8 @@ public class FregeDTO {
     }
 
     private boolean isGetterProperty(Method method) {
-        return method.getName().startsWith("get") && method.getReturnType().getName().contains("Property");
+        return method.getName().startsWith("get") &&
+               method.getReturnType().getName().contains("Property");
     }
 
     private String stripGetPrefixAndDecapitalize(String s) {
@@ -89,9 +105,14 @@ public class FregeDTO {
     }
 
     public String toBuildFile() {
-        Stream<Method> methods = Arrays.stream(FregeExtension.class.getMethods());
-        Stream<Field> fields = methods.filter(m -> isGetterProperty(m))
-                .map(m -> stripGetPrefixAndDecapitalize(m.getName())).map(name -> getField(name));
-        return fields.filter(f -> !isEmpty(f)).map(f -> toKeyValuePairs(f)).collect(Collectors.joining("\n  "));
+        Stream<Field> fields =
+            Arrays.stream(FregeExtension.class.getMethods())
+            .filter(m -> isGetterProperty(m))
+            .map(m -> stripGetPrefixAndDecapitalize(m.getName()))
+            .map(name -> getField(name));
+        return fields
+               .filter(f -> !isEmpty(f))
+               .map(f -> toKeyValuePairs(f))
+               .collect(Collectors.joining("\n  "));
     }
 }

--- a/src/test/java/ch/fhnw/thga/gradleplugins/FregeDTO.java
+++ b/src/test/java/ch/fhnw/thga/gradleplugins/FregeDTO.java
@@ -14,7 +14,7 @@ public class FregeDTO {
     public final String outputDir;
     public final String mainModule;
     public final String compilerFlags;
-    public final String replModule;
+    public final String replSource;
 
     public FregeDTO(
         String version,
@@ -24,7 +24,7 @@ public class FregeDTO {
         String outputDir,
         String mainModule,
         String compilerFlags,
-        String replModule) {
+        String replSource) {
         this.version = version;
         this.release = release;
         this.compilerDownloadDir = compilerDownloadDir;
@@ -32,7 +32,7 @@ public class FregeDTO {
         this.outputDir = outputDir;
         this.mainModule = mainModule;
         this.compilerFlags = compilerFlags;
-        this.replModule = replModule;
+        this.replSource = replSource;
     }
 
     public String getVersion() {
@@ -63,8 +63,8 @@ public class FregeDTO {
         return compilerFlags;
     }
 
-    public String getReplModule() {
-        return replModule;
+    public String getReplSource() {
+        return replSource;
     }
 
     private String getFieldValue(Field field) {

--- a/src/test/java/ch/fhnw/thga/gradleplugins/FregeDTOBuilder.java
+++ b/src/test/java/ch/fhnw/thga/gradleplugins/FregeDTOBuilder.java
@@ -8,7 +8,7 @@ public final class FregeDTOBuilder implements Builder {
     private String outputDir = "";
     private String mainModule = "";
     private String compilerFlags = "";
-    private String replModule = "";
+    private String replSource = "";
 
     private static volatile FregeDTOBuilder instance;
 
@@ -74,9 +74,9 @@ public final class FregeDTOBuilder implements Builder {
     }
 
     @Override
-    public Builder replModule(String replModule)
+    public Builder replSource(String replSource)
     {
-        this.replModule = replModule;
+        this.replSource = replSource;
         return this;
     }
 
@@ -89,6 +89,6 @@ public final class FregeDTOBuilder implements Builder {
             outputDir,
             mainModule,
             compilerFlags,
-            replModule);
+            replSource);
     }
 }

--- a/src/test/java/ch/fhnw/thga/gradleplugins/FregeDTOBuilder.java
+++ b/src/test/java/ch/fhnw/thga/gradleplugins/FregeDTOBuilder.java
@@ -8,6 +8,7 @@ public final class FregeDTOBuilder implements Builder {
     private String outputDir = "";
     private String mainModule = "";
     private String compilerFlags = "";
+    private String replModule = "";
 
     private static volatile FregeDTOBuilder instance;
 
@@ -72,7 +73,22 @@ public final class FregeDTOBuilder implements Builder {
         return this;
     }
 
+    @Override
+    public Builder replModule(String replModule)
+    {
+        this.replModule = replModule;
+        return this;
+    }
+
     public FregeDTO build() {
-        return new FregeDTO(version, release, compilerDownloadDir, mainSourceDir, outputDir, mainModule, compilerFlags);
+        return new FregeDTO(
+            version,
+            release,
+            compilerDownloadDir,
+            mainSourceDir,
+            outputDir,
+            mainModule,
+            compilerFlags,
+            replModule);
     }
 }


### PR DESCRIPTION
Fixes #16.

## New Features
The new `replSource` property specifies the frege source file that you want to
load into the repl. It is excluded in the `fregeCompile` task so that
we don't get two java class files (one from `compileFrege` and one
from the fregeRepl `:l` command) that shadow each other on the classpath.

As a result, all files except the `replSource` get compiled, we can make interactive changes to the `replSource` file and
use the `:r` reload command in the repl to see them.