### PR TITLE
Add support for the frege-intellij plugin

### DIFF
--- a/src/main/java/ch/fhnw/thga/gradleplugins/FregePlugin.java
+++ b/src/main/java/ch/fhnw/thga/gradleplugins/FregePlugin.java
@@ -1,28 +1,31 @@
 package ch.fhnw.thga.gradleplugins;
 
+import ch.fhnw.thga.gradleplugins.internal.DependencyFregeTask;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.tasks.TaskProvider;
 
-import ch.fhnw.thga.gradleplugins.internal.DependencyFregeTask;
-
-public class FregePlugin implements Plugin<Project>
-{
-    public static final String SETUP_FREGE_TASK_NAME      = "setupFrege";
-    public static final String COMPILE_FREGE_TASK_NAME    = "compileFrege";
-    public static final String RUN_FREGE_TASK_NAME        = "runFrege";
-    public static final String REPL_FREGE_TASK_NAME       = "replFrege";
-    public static final String DEPS_FREGE_TASK_NAME       = "depsFrege";
-    public static final String FREGE_PLUGIN_ID            = "ch.fhnw.thga.frege";
-    public static final String FREGE_EXTENSION_NAME       = "frege";
-    public static final String FREGE_IMPLEMENTATION_SCOPE = "implementation";
+public class FregePlugin implements Plugin<Project> {
+    public static final String SETUP_FREGE_TASK_NAME = "setupFrege";
+    public static final String COMPILE_FREGE_TASK_NAME = "compileFrege";
+    public static final String RUN_FREGE_TASK_NAME = "runFrege";
+    public static final String RUN_FREGE_TASK_NAME_ALTERNATIVE = "fregeRun";
+    public static final String RUN_FREGE_TASK_MODULE_OVERRIDE = "class_name"; // Used by intellij-frege to run arbitary files
+    public static final String REPL_FREGE_TASK_NAME = "replFrege";
+    public static final String DEPS_FREGE_TASK_NAME = "depsFrege";
+    public static final String FREGE_PLUGIN_ID = "ch.fhnw.thga.frege";
+    public static final String FREGE_EXTENSION_NAME = "frege";
+    public static final String FREGE_DEPENDENCY_SCOPE = "implementation";
+    public static final String FREGE_RESOLVED_SCOPE = "fregeResolved";
 
     @Override
     public void apply(Project project) {
-        Configuration implementation = project
-                                       .getConfigurations()
-                                       .create(FREGE_IMPLEMENTATION_SCOPE);
+        Configuration implementation = project.getConfigurations().maybeCreate(FREGE_DEPENDENCY_SCOPE);
+        Configuration resolvedImplementation = project.getConfigurations().maybeCreate("fregeResolvedImplementation");
+        resolvedImplementation.extendsFrom(implementation);
+        Configuration fregeResolved = project.getConfigurations().create(FREGE_RESOLVED_SCOPE);
+        implementation.extendsFrom(fregeResolved);
 
         FregeExtension extension     = project
                                        .getExtensions()
@@ -53,23 +56,34 @@ public class FregePlugin implements Plugin<Project>
                     task.getFregeMainSourceDir().set(extension.getMainSourceDir());
                     task.getFregeOutputDir().set(extension.getOutputDir());
                     task.getFregeCompilerFlags().set(extension.getCompilerFlags());
-                    task.getFregeDependencies().set(implementation.getAsPath());
+                    task.getFregeDependencies().set(resolvedImplementation.getAsPath());
                     task.getReplSource().set("");
                 }
             );
 
+        TaskProvider<RunFregeTask> runFregeTask = project.getTasks().register(
+                RUN_FREGE_TASK_NAME,
+                RunFregeTask.class,
+                task ->
+                {
+                    task.dependsOn(compileFregeTask);
+                    task.getFregeCompilerJar().set(
+                            setupFregeCompilerTask.get().getFregeCompilerOutputPath());
+                    task.getFregeOutputDir().set(extension.getOutputDir());
+                    if(project.hasProperty(RUN_FREGE_TASK_MODULE_OVERRIDE)) {
+                        task.getMainModule().set(project.findProperty(RUN_FREGE_TASK_MODULE_OVERRIDE).toString());
+                    }else {
+                        task.getMainModule().set(extension.getMainModule());
+                    }
+                    task.getFregeDependencies().set(resolvedImplementation.getAsPath());
+                }
+        );
+
         project.getTasks().register(
-            RUN_FREGE_TASK_NAME,
-            RunFregeTask.class,
-            task ->
-            {
-                task.dependsOn(compileFregeTask);
-                task.getFregeCompilerJar().set(
-                    setupFregeCompilerTask.get().getFregeCompilerOutputPath());
-                task.getFregeOutputDir().set(extension.getOutputDir());
-                task.getMainModule().set(extension.getMainModule());
-                task.getFregeDependencies().set(implementation.getAsPath());
-            }
+                RUN_FREGE_TASK_NAME_ALTERNATIVE,
+                task -> {
+                    task.dependsOn(runFregeTask);
+                }
         );
 
         project.getTasks().register(
@@ -88,7 +102,7 @@ public class FregePlugin implements Plugin<Project>
                 task.getFregeCompilerJar().set(
                     setupFregeCompilerTask.get().getFregeCompilerOutputPath());
                 task.getFregeOutputDir().set(extension.getOutputDir());
-                task.getFregeDependencies().set(implementation.getAsPath());
+                task.getFregeDependencies().set(resolvedImplementation.getAsPath());
             }
         );
 
@@ -108,8 +122,13 @@ public class FregePlugin implements Plugin<Project>
                 task.getFregeCompilerJar().set(
                     setupFregeCompilerTask.get().getFregeCompilerOutputPath());
                 task.getFregeOutputDir().set(extension.getOutputDir());
-                task.getFregeDependencies().set(implementation.getAsPath());
+                task.getFregeDependencies().set(resolvedImplementation.getAsPath());
             }
         );
+
+
+        project.afterEvaluate(ignored -> {
+            project.getDependencies().add(FREGE_RESOLVED_SCOPE, setupFregeCompilerTask.map(SetupFregeTask::getFregeCompilerOutputPath).map(project::files));
+        });
     }
 }


### PR DESCRIPTION
This commit adds support for the frege intellij plugin by

 - exposing the frege compiler jar as a dependency, so the plugin can
   recognize the standard library.
 - adding the name 'fregeRun' as that is used by the plugin to run files
 - add support for overriding the main module executed by runFrege so
   that arbitary files can be run by the plugin

The frege-intellij plugin: https://github.com/IntelliJ-Frege/intellij-frege