### PR TITLE
Only Compile Specified Files if Specified

### DIFF
--- a/example-project/build.gradle
+++ b/example-project/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'ch.fhnw.thga.frege' version '1.7.0-alpha'
+    id 'ch.fhnw.thga.frege' version '1.7.1-alpha'
 }
 
 frege {

--- a/example-project/src/main/frege/ch/fhnw/thga/Hello.fr
+++ b/example-project/src/main/frege/ch/fhnw/thga/Hello.fr
@@ -1,0 +1,4 @@
+module ch.fhnw.thga.Hello where
+
+main = do
+  println "Hello"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group = ch.fhnw.thga
-version = 1.7.0-alpha
+version = 1.7.1-alpha

--- a/src/functionalTest/java/ch/fhnw/thga/gradleplugins/RunFregeTaskFunctionalTest.java
+++ b/src/functionalTest/java/ch/fhnw/thga/gradleplugins/RunFregeTaskFunctionalTest.java
@@ -7,6 +7,8 @@ import static ch.fhnw.thga.gradleplugins.SharedFunctionalTestLogic.createFregeSe
 import static ch.fhnw.thga.gradleplugins.SharedFunctionalTestLogic.runAndFailGradleTask;
 import static ch.fhnw.thga.gradleplugins.SharedFunctionalTestLogic.runGradleTask;
 import static ch.fhnw.thga.gradleplugins.SharedFunctionalTestLogic.MINIMAL_BUILD_FILE_CONFIG;
+import static ch.fhnw.thga.gradleplugins.SharedFunctionalTestLogic.COMPLETION_FR;
+import static ch.fhnw.thga.gradleplugins.SharedFunctionalTestLogic.assertFileDoesNotExist;
 import static org.gradle.testkit.runner.TaskOutcome.FAILED;
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -116,7 +118,46 @@ public class RunFregeTaskFunctionalTest
             );
             assertTrue(result.getOutput().contains("Frege rocks"));
         }
+
+        @Test
+        void given_two_frege_files_then_only_the_specified_main_module_is_compiled(
+            @TempDir File testProjectDir)
+            throws Exception
+        {
+            Project project = FregeProjectBuilder
+                .builder()
+                .projectRoot(testProjectDir)
+                .buildFile(MINIMAL_BUILD_FILE_CONFIG)
+                .fregeSourceFiles(() -> Stream.of(MAIN_FR, COMPLETION_FR))
+                .build();
+            
+            BuildResult result = runGradleTask(
+                testProjectDir,
+                RUN_FREGE_TASK_NAME,
+                "--mainModule=ch.fhnw.thga.Main");
+            
+            assertTrue(
+                project
+                .getTasks()
+                .getByName(RUN_FREGE_TASK_NAME) 
+                instanceof RunFregeTask
+            );
+            assertEquals(
+                SUCCESS,
+                result.task(":" + RUN_FREGE_TASK_NAME).getOutcome()
+            );
+            assertTrue(result.getOutput().contains("Frege rocks"));
+            assertFileDoesNotExist(
+                testProjectDir,
+                "build/classes/main/frege/ch/fhnw/thga/Completion.java"
+            );
+            assertFileDoesNotExist(
+                testProjectDir,
+                "build/classes/main/frege/ch/fhnw/thga/Completion.class"
+            );
+        }
     }
+    
     @Nested
     @IndicativeSentencesGeneration(
         separator = " -> ",

--- a/src/main/java/ch/fhnw/thga/gradleplugins/FregePlugin.java
+++ b/src/main/java/ch/fhnw/thga/gradleplugins/FregePlugin.java
@@ -3,6 +3,7 @@ package ch.fhnw.thga.gradleplugins;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.logging.LogLevel;
 import org.gradle.api.tasks.TaskProvider;
 
 public class FregePlugin implements Plugin<Project>
@@ -52,7 +53,6 @@ public class FregePlugin implements Plugin<Project>
                     task.getFregeOutputDir().set(extension.getOutputDir());
                     task.getFregeCompilerFlags().set(extension.getCompilerFlags());
                     task.getFregeDependencies().set(implementation.getAsPath());
-                    task.getFregeCompileItem().set("");
                 }
             );
 
@@ -61,7 +61,6 @@ public class FregePlugin implements Plugin<Project>
             RunFregeTask.class,
             task ->
             {
-                
                 task.getMainModule().set(extension.getMainModule());
                 task.dependsOn(compileFregeTask.map(
                     compileTask ->
@@ -69,7 +68,7 @@ public class FregePlugin implements Plugin<Project>
                         compileTask.getFregeCompileItem().set(task.getMainModule());
                         return compileTask;
                     }
-                ));
+                ).get());
                 task.getFregeCompilerJar().set(
                     setupFregeCompilerTask.get().getFregeCompilerOutputPath());
                 task.getFregeOutputDir().set(extension.getOutputDir());
@@ -86,10 +85,12 @@ public class FregePlugin implements Plugin<Project>
                 task.dependsOn(compileFregeTask.map(
                     compileTask ->
                     {
-                        compileTask.getFregeCompileItem().set(task.getReplModule());
+                        compileTask.getFregeCompileItem().set(extension.getReplModule());
+                        compileTask.getLogging().captureStandardOutput(LogLevel.LIFECYCLE);
+                        compileTask.getLogging().captureStandardError(LogLevel.LIFECYCLE);
                         return compileTask;
                     }
-                ));
+                ).get());
                 task.getFregeCompilerJar().set(
                     setupFregeCompilerTask.get().getFregeCompilerOutputPath());
                 task.getFregeOutputDir().set(extension.getOutputDir());


### PR DESCRIPTION
Fixes #25 and fixes #24.

The runFrege and replFrege tasks now only compile the specified modules by `mainModule` and `replModule` instead of all files.