### PR TITLE
Adds initFrege Task

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Simplifies setting up your Frege project.
 
 ## Installation
 
-You need `java >= 11`.
+You need `java >= 11` and `gradle >= 7`.
 
 ```bash
 git clone https://github.com/tricktron/frege-gradle-plugin.git
@@ -14,16 +14,28 @@ git clone https://github.com/tricktron/frege-gradle-plugin.git
 ```
 
 ## How to Use
-1. Specify the frege compiler release, version, main module and repl source 
+1. Specify the frege compiler release, version, main module and repl module 
 file in your `build.gradle`:
 
 ```groovy
-frege {
-    version = '3.25.84'
-    release = '3.25alpha'
-    mainModule = 'my.mod.Name' // see runFrege task
-    replModule = 'my.mod.Name' // see replFrege task
+plugins
+{
+    id 'ch.fhnw.thga.frege' version '1.9.0-alpha'
 }
+
+frege 
+{
+    version    = '3.25.84'
+    release    = '3.25alpha'
+    mainModule = 'examples.HelloFrege' // see runFrege task
+    replModule = 'examples.HelloFrege' // see replFrege task
+}
+```
+
+Then run
+```bash
+gradle initFrege
+gradle runFrege
 ```
 
 See the [Frege Releases](https://github.com/Frege/frege/releases) for all available versions.
@@ -37,6 +49,9 @@ Optional configuration parameters inside `build.gradle`:
 ### Added Tasks
 
 - **setupFrege**: Downloads the specified version of the Frege compiler.
+- **initFrege**: Creates a default `HelloFrege.fr` example file under
+ `mainSource/examples/HelloFrege.fr`. Alternatively, you can specify the location
+ on the command line with `--mainModule=my.mod.HelloFrege`.
 - **compileFrege**: Compiles all your `*.fr` files in `mainSourceDir` to `outputDir`.
 Alternatively, you can also pass the compile item by command line. Then only the
 compile item and its dependencies get compiled. 

--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,5 @@ tasks.withType(Test).configureEach
     {
         includeEngines 'jqwik', 'junit-jupiter'
         maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
-        excludeTags 'network'
     }
 }

--- a/example-project/build.gradle
+++ b/example-project/build.gradle
@@ -1,10 +1,10 @@
 plugins {
-    id 'ch.fhnw.thga.frege' version '1.8.0-alpha'
+    id 'ch.fhnw.thga.frege' version '1.9.0-alpha'
 }
 
 frege {
     version = '3.25.84'
     release = '3.25alpha'
-    mainModule = 'ch.fhnw.thga.Test'
-    replModule = 'ch.fhnw.thga.Test'
+    mainModule = 'ch.fhnw.thga.HelloFrege'
+    replModule = 'ch.fhnw.thga.HelloFrege'
 }

--- a/example-project/src/main/frege/ch/fhnw/thga/HelloFrege.fr
+++ b/example-project/src/main/frege/ch/fhnw/thga/HelloFrege.fr
@@ -1,0 +1,27 @@
+module ch.fhnw.thga.HelloFrege where
+
+import Test.QuickCheck
+
+--- compute digit sum
+digitSum :: Integer -> Integer
+digitSum 0 = 0
+digitSum n = (n `rem` 10) + digitSum (n `div` 10)
+
+--- compute the reduced digit sum
+reducedDigitSum :: Integer -> Integer
+reducedDigitSum n = if n < 10 then n else reducedDigitSum $ digitSum n
+
+main = do
+    let answer = digitSum 6666666
+    println $
+        "The answer to life, the universe and everything is "
+        ++ show answer
+        ++ "."
+
+{--
+    The property 'p_reduced_digit_sum_of_multiple_of_9_is_always_9' checks
+    the famous claim that every multiple of 9 number has also the reduced
+    digit sum of 9, e.g. 9, 27, 36, ...
+-}
+p_reduced_digit_sum_of_multiple_of_9_is_always_9 = 
+    property $ \(n :: Integer) -> (n > 0) ==> (reducedDigitSum $ 9 * n) == 9

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group = ch.fhnw.thga
-version = 1.8.0-alpha
+version = 1.9.0-alpha

--- a/src/functionalTest/java/ch/fhnw/thga/gradleplugins/CompileFregeTaskFunctionalTest.java
+++ b/src/functionalTest/java/ch/fhnw/thga/gradleplugins/CompileFregeTaskFunctionalTest.java
@@ -5,7 +5,7 @@ import static ch.fhnw.thga.gradleplugins.FregePlugin.COMPILE_FREGE_TASK_NAME;
 import static ch.fhnw.thga.gradleplugins.SharedFunctionalTestLogic.createFregeSection;
 import static ch.fhnw.thga.gradleplugins.SharedFunctionalTestLogic.runAndFailGradleTask;
 import static ch.fhnw.thga.gradleplugins.SharedFunctionalTestLogic.runGradleTask;
-import static ch.fhnw.thga.gradleplugins.SharedFunctionalTestLogic.NEW_LINE;
+import static ch.fhnw.thga.gradleplugins.SharedTaskLogic.NEW_LINE;
 import static ch.fhnw.thga.gradleplugins.SharedFunctionalTestLogic.MINIMAL_BUILD_FILE_CONFIG;
 import static ch.fhnw.thga.gradleplugins.SharedFunctionalTestLogic.COMPLETION_FR;
 import static ch.fhnw.thga.gradleplugins.SharedFunctionalTestLogic.assertFileExists;

--- a/src/functionalTest/java/ch/fhnw/thga/gradleplugins/InitFregeTaskFunctionalTest.java
+++ b/src/functionalTest/java/ch/fhnw/thga/gradleplugins/InitFregeTaskFunctionalTest.java
@@ -1,0 +1,96 @@
+package ch.fhnw.thga.gradleplugins;
+
+import static ch.fhnw.thga.gradleplugins.FregeExtension.DEFAULT_RELATIVE_SOURCE_DIR;
+import static ch.fhnw.thga.gradleplugins.FregePlugin.COMPILE_FREGE_TASK_NAME;
+import static ch.fhnw.thga.gradleplugins.FregePlugin.INIT_FREGE_TASK_NAME;
+import static ch.fhnw.thga.gradleplugins.SharedFunctionalTestLogic.MINIMAL_BUILD_FILE_CONFIG;
+import static ch.fhnw.thga.gradleplugins.SharedFunctionalTestLogic.assertFileExists;
+import static ch.fhnw.thga.gradleplugins.SharedFunctionalTestLogic.runGradleTask;
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+
+import org.gradle.api.Project;
+import org.gradle.testkit.runner.BuildResult;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.IndicativeSentencesGeneration;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import ch.fhnw.thga.gradleplugins.fregeproject.FregeProjectBuilder;
+import ch.fhnw.thga.gradleplugins.fregeproject.ProjectRoot;
+
+public class InitFregeTaskFunctionalTest
+{
+    private static ProjectRoot FREGE_PROJECT_BUILDER = FregeProjectBuilder.builder();
+
+    @Nested
+    @IndicativeSentencesGeneration(
+        separator = " -> ",
+        generator = DisplayNameGenerator.ReplaceUnderscores.class)
+    class Init_frege_task_works {
+        @Test
+        void given_minimal_build_file_config(
+            @TempDir File testProjectDir)
+            throws Exception
+        {
+            Project project = FREGE_PROJECT_BUILDER
+                .projectRoot(testProjectDir)
+                .buildFile(MINIMAL_BUILD_FILE_CONFIG)
+                .build();
+
+            BuildResult result = runGradleTask(testProjectDir, INIT_FREGE_TASK_NAME);
+    
+            assertTrue(
+                project
+                .getTasks()
+                .getByName(INIT_FREGE_TASK_NAME) instanceof InitFregeTask
+            );
+            assertEquals(
+                SUCCESS,
+                result.task(":" + INIT_FREGE_TASK_NAME).getOutcome()
+            );
+            assertFileExists(
+                testProjectDir.toPath().resolve(DEFAULT_RELATIVE_SOURCE_DIR).toFile(),
+                "examples/HelloFrege.fr"
+            );
+
+            BuildResult compileHelloFrege = runGradleTask(testProjectDir, COMPILE_FREGE_TASK_NAME);
+            assertEquals(SUCCESS, compileHelloFrege.task(":" + COMPILE_FREGE_TASK_NAME).getOutcome());
+        }
+
+        @Test
+        void given_custom_module_name_on_command_line(
+            @TempDir File testProjectDir)
+            throws Exception
+        {
+            Project project = FREGE_PROJECT_BUILDER
+                .projectRoot(testProjectDir)
+                .buildFile(MINIMAL_BUILD_FILE_CONFIG)
+                .build();
+
+            BuildResult result = runGradleTask(
+                testProjectDir,
+                INIT_FREGE_TASK_NAME,
+                "--moduleName=ch.fhnw.thga.HelloFrege"
+            );
+    
+            assertTrue(
+                project
+                .getTasks()
+                .getByName(INIT_FREGE_TASK_NAME) instanceof InitFregeTask
+            );
+            assertEquals(
+                SUCCESS,
+                result.task(":" + INIT_FREGE_TASK_NAME).getOutcome()
+            );
+            assertFileExists(
+                testProjectDir.toPath().resolve(DEFAULT_RELATIVE_SOURCE_DIR).toFile(),
+                "ch/fhnw/thga/HelloFrege.fr"
+            );
+        }
+    }
+}

--- a/src/functionalTest/java/ch/fhnw/thga/gradleplugins/ReplFregeTaskFunctionalTest.java
+++ b/src/functionalTest/java/ch/fhnw/thga/gradleplugins/ReplFregeTaskFunctionalTest.java
@@ -4,7 +4,7 @@ import static ch.fhnw.thga.gradleplugins.FregeExtension.DEFAULT_RELATIVE_SOURCE_
 import static ch.fhnw.thga.gradleplugins.FregePlugin.REPL_FREGE_TASK_NAME;
 import static ch.fhnw.thga.gradleplugins.SharedFunctionalTestLogic.COMPLETION_FR;
 import static ch.fhnw.thga.gradleplugins.SharedFunctionalTestLogic.MINIMAL_BUILD_FILE_CONFIG;
-import static ch.fhnw.thga.gradleplugins.SharedFunctionalTestLogic.NEW_LINE;
+import static ch.fhnw.thga.gradleplugins.SharedTaskLogic.NEW_LINE;
 import static ch.fhnw.thga.gradleplugins.SharedFunctionalTestLogic.assertFileDoesNotExist;
 import static ch.fhnw.thga.gradleplugins.SharedFunctionalTestLogic.assertFileExists;
 import static ch.fhnw.thga.gradleplugins.SharedFunctionalTestLogic.createFregeSection;

--- a/src/functionalTest/java/ch/fhnw/thga/gradleplugins/RunFregeTaskFunctionalTest.java
+++ b/src/functionalTest/java/ch/fhnw/thga/gradleplugins/RunFregeTaskFunctionalTest.java
@@ -2,7 +2,7 @@ package ch.fhnw.thga.gradleplugins;
 
 import static ch.fhnw.thga.gradleplugins.FregeExtension.DEFAULT_RELATIVE_SOURCE_DIR;
 import static ch.fhnw.thga.gradleplugins.FregePlugin.RUN_FREGE_TASK_NAME;
-import static ch.fhnw.thga.gradleplugins.SharedFunctionalTestLogic.NEW_LINE;
+import static ch.fhnw.thga.gradleplugins.SharedTaskLogic.NEW_LINE;
 import static ch.fhnw.thga.gradleplugins.SharedFunctionalTestLogic.createFregeSection;
 import static ch.fhnw.thga.gradleplugins.SharedFunctionalTestLogic.runAndFailGradleTask;
 import static ch.fhnw.thga.gradleplugins.SharedFunctionalTestLogic.runGradleTask;

--- a/src/functionalTest/java/ch/fhnw/thga/gradleplugins/SetupFregeTaskFunctionalTest.java
+++ b/src/functionalTest/java/ch/fhnw/thga/gradleplugins/SetupFregeTaskFunctionalTest.java
@@ -2,6 +2,7 @@ package ch.fhnw.thga.gradleplugins;
 
 import static ch.fhnw.thga.gradleplugins.FregeExtension.DEFAULT_RELATIVE_COMPILER_DOWNLOAD_DIR;
 import static ch.fhnw.thga.gradleplugins.FregePlugin.SETUP_FREGE_TASK_NAME;
+import static ch.fhnw.thga.gradleplugins.SharedFunctionalTestLogic.assertFileExists;
 import static ch.fhnw.thga.gradleplugins.SharedFunctionalTestLogic.createFregeSection;
 import static ch.fhnw.thga.gradleplugins.SharedFunctionalTestLogic.runGradleTask;
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS;
@@ -16,8 +17,8 @@ import org.gradle.testkit.runner.BuildResult;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.IndicativeSentencesGeneration;
 import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import ch.fhnw.thga.gradleplugins.fregeproject.FregeProjectBuilder;
@@ -26,20 +27,22 @@ import ch.fhnw.thga.gradleplugins.fregeproject.ProjectRoot;
 @Tag("network")
 class SetupFregeTaskFunctionalTest
 {
-    private static FregeDTOBuilder FREGE_BUILDER             = FregeDTOBuilder.builder();
+    private static FregeDTOBuilder FREGE_BUILDER     = FregeDTOBuilder.builder();
     private static ProjectRoot FREGE_PROJECT_BUILDER = FregeProjectBuilder.builder();
 
     @Nested
-    @IndicativeSentencesGeneration(separator = " -> ", generator = DisplayNameGenerator.ReplaceUnderscores.class)
+    @IndicativeSentencesGeneration(
+        separator = " -> ",
+        generator = DisplayNameGenerator.ReplaceUnderscores.class)
     class Setup_frege_task_works {
         @Test
         void given_minimal_build_file_config(@TempDir File testProjectDir) throws Exception
         {
             String minimalBuildFileConfig = createFregeSection(
                 FREGE_BUILDER
-                    .version("'3.25.84'")
-                    .release("'3.25alpha'")
-                    .build()
+                .version("'3.25.84'")
+                .release("'3.25alpha'")
+                .build()
             );
 
             Project project = FREGE_PROJECT_BUILDER
@@ -56,12 +59,9 @@ class SetupFregeTaskFunctionalTest
                 .getByName(SETUP_FREGE_TASK_NAME) instanceof SetupFregeTask
             );
             assertEquals(SUCCESS, result.task(":" + SETUP_FREGE_TASK_NAME).getOutcome());
-            assertTrue(
-                testProjectDir
-                .toPath()
-                .resolve(Paths.get(DEFAULT_RELATIVE_COMPILER_DOWNLOAD_DIR, "frege3.25.84.jar"))
-                .toFile()
-                .exists()
+            assertFileExists(
+                testProjectDir,
+                Paths.get(DEFAULT_RELATIVE_COMPILER_DOWNLOAD_DIR, "frege3.25.84.jar").toString()
             );
         }
     
@@ -92,12 +92,9 @@ class SetupFregeTaskFunctionalTest
                 .getByName(SETUP_FREGE_TASK_NAME) instanceof SetupFregeTask
             );
             assertEquals(SUCCESS, result.task(":" + SETUP_FREGE_TASK_NAME).getOutcome());
-            assertTrue(
-                testProjectDir
-                .toPath()
-                .resolve(Paths.get("dist", "frege3.25.84.jar"))
-                .toFile()
-                .exists()
+            assertFileExists(
+                testProjectDir,
+                Paths.get("dist", "frege3.25.84.jar").toString()
             );
         }
     }

--- a/src/functionalTest/java/ch/fhnw/thga/gradleplugins/SharedFunctionalTestLogic.java
+++ b/src/functionalTest/java/ch/fhnw/thga/gradleplugins/SharedFunctionalTestLogic.java
@@ -1,20 +1,13 @@
 package ch.fhnw.thga.gradleplugins;
 
+import static ch.fhnw.thga.gradleplugins.FregeExtension.DEFAULT_RELATIVE_SOURCE_DIR;
 import static ch.fhnw.thga.gradleplugins.FregePlugin.FREGE_EXTENSION_NAME;
-import static ch.fhnw.thga.gradleplugins.FregePlugin.FREGE_PLUGIN_ID;
-import static ch.fhnw.thga.gradleplugins.GradleBuildFileConversionTest.createPluginsSection;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static ch.fhnw.thga.gradleplugins.FregeExtension.DEFAULT_RELATIVE_SOURCE_DIR;
+import static ch.fhnw.thga.gradleplugins.SharedTaskLogic.NEW_LINE;
 
-import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.util.stream.Stream;
 
-import org.gradle.api.Project;
-import org.gradle.testfixtures.ProjectBuilder;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.GradleRunner;
 
@@ -22,7 +15,6 @@ import ch.fhnw.thga.gradleplugins.fregeproject.FregeSourceFile;
 
 public class SharedFunctionalTestLogic
 {
-    public static final String NEW_LINE = System.lineSeparator();
     public static final String MINIMAL_BUILD_FILE_CONFIG = createFregeSection(
         FregeDTOBuilder
         .builder()
@@ -83,31 +75,6 @@ public class SharedFunctionalTestLogic
             System.lineSeparator());
     }
 
-    private static void writeFile(
-        File destination,
-        String content,
-        boolean append) 
-        throws IOException
-    {
-        try (BufferedWriter output = new BufferedWriter(new FileWriter(destination, append)))
-        {
-                output.write(content);
-        }
-    
-    }
-
-    static File writeToFile(File destination, String content) throws IOException
-    {
-        writeFile(destination, content, false);
-        return destination;
-    }
-
-    static File appendToFile(File destination, String content) throws IOException
-    {
-        writeFile(destination, System.lineSeparator() + content, true);
-        return destination;
-    }
-
     static BuildResult runGradleTask(File testProjectDir, String... args)
     {
         return GradleRunner
@@ -127,46 +94,4 @@ public class SharedFunctionalTestLogic
             .withArguments(args)
             .buildAndFail();
     }
-
-    static File createSettingsFile(File testProjectDir) throws IOException 
-        {
-            File settingsFile = new File(testProjectDir, "settings.gradle");
-            return writeToFile(settingsFile, "rootProject.name='frege-plugin'");
-        }
-    
-        private static File createFregePluginBuildFile(
-            File testProjectDir)
-            throws IOException
-        {
-            File buildFile = new File(testProjectDir, "build.gradle");
-            return writeToFile(
-                buildFile,
-                createPluginsSection(Stream.of(FREGE_PLUGIN_ID)));
-        }
-    
-        static File createFregeBuildFile(
-            File testProjectDir,
-            String fregeBuildFileConfig)
-            throws IOException
-        {
-            return appendToFile(
-                createFregePluginBuildFile(
-                    testProjectDir),
-                    fregeBuildFileConfig);
-        }
-    
-        static Project createFregeGradleProject(
-            File testProjectDir,
-            String fregeBuildFileConfig)
-            throws Exception
-        {
-            createSettingsFile(testProjectDir);
-            createFregeBuildFile(testProjectDir, fregeBuildFileConfig);
-            Project project = ProjectBuilder
-                .builder()
-                .withProjectDir(testProjectDir)
-                .build();
-            project.getPluginManager().apply(FREGE_PLUGIN_ID);
-            return project;
-        }
 }

--- a/src/main/java/ch/fhnw/thga/gradleplugins/FregePlugin.java
+++ b/src/main/java/ch/fhnw/thga/gradleplugins/FregePlugin.java
@@ -1,10 +1,10 @@
 package ch.fhnw.thga.gradleplugins;
 
 import org.gradle.api.Plugin;
-import org.gradle.api.plugins.BasePlugin;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.logging.LogLevel;
+import org.gradle.api.plugins.BasePlugin;
 import org.gradle.api.tasks.TaskProvider;
 
 public class FregePlugin implements Plugin<Project>
@@ -13,7 +13,7 @@ public class FregePlugin implements Plugin<Project>
     public static final String COMPILE_FREGE_TASK_NAME    = "compileFrege";
     public static final String RUN_FREGE_TASK_NAME        = "runFrege";
     public static final String REPL_FREGE_TASK_NAME       = "replFrege";
-    public static final String DEPS_FREGE_TASK_NAME       = "depsFrege";
+    public static final String INIT_FREGE_TASK_NAME       = "initFrege";
     public static final String FREGE_PLUGIN_ID            = "ch.fhnw.thga.frege";
     public static final String FREGE_EXTENSION_NAME       = "frege";
     public static final String FREGE_IMPLEMENTATION_SCOPE = "implementation";
@@ -31,6 +31,16 @@ public class FregePlugin implements Plugin<Project>
                                        FregeExtension.class);
         
         project.getPlugins().apply(BasePlugin.class);
+
+        project.getTasks().register(
+            INIT_FREGE_TASK_NAME,
+            InitFregeTask.class,
+            task ->
+            {
+                task.getFregeMainSourceDir().set(extension.getMainSourceDir());
+                task.getFregeModuleName().set("examples.HelloFrege");
+            }
+        );
 
         TaskProvider<SetupFregeTask> setupFregeCompilerTask =
             project.getTasks().register(

--- a/src/main/java/ch/fhnw/thga/gradleplugins/InitFregeTask.java
+++ b/src/main/java/ch/fhnw/thga/gradleplugins/InitFregeTask.java
@@ -1,0 +1,94 @@
+package ch.fhnw.thga.gradleplugins;
+
+import static ch.fhnw.thga.gradleplugins.SharedTaskLogic.NEW_LINE;
+
+import java.io.IOException;
+import java.nio.file.Paths;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.file.RegularFile;
+import org.gradle.api.provider.Property;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Internal;
+import org.gradle.api.tasks.OutputDirectory;
+import org.gradle.api.tasks.OutputFile;
+import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.tasks.options.Option;
+
+public abstract class InitFregeTask extends DefaultTask
+{
+    private static final String EMPTY_LINE = "";
+    private static final String HELLO_FREGE_CODE_WITHOUT_MODULE = String.join(NEW_LINE,
+        "import Test.QuickCheck",
+        EMPTY_LINE,
+        "--- compute digit sum",
+        "digitSum :: Integer -> Integer",
+        "digitSum 0 = 0",
+        "digitSum n = (n `rem` 10) + digitSum (n `div` 10)",
+        EMPTY_LINE,
+        "--- compute the reduced digit sum",
+        "reducedDigitSum :: Integer -> Integer",
+        "reducedDigitSum n = if n < 10 then n else reducedDigitSum $ digitSum n",
+        EMPTY_LINE,
+        "main = do",
+        "    let answer = digitSum 6666666",
+        "    println $",
+        "        \"The answer to life, the universe and everything is \"",
+        "        ++ show answer",
+        "        ++ \".\"",
+        EMPTY_LINE,
+        "{--",
+        "    The property 'p_reduced_digit_sum_of_multiple_of_9_is_always_9' checks",
+        "    the famous claim that every multiple of 9 number has also the reduced",
+        "    digit sum of 9, e.g. 9, 27, 36, ...", 
+        "-}",
+        "p_reduced_digit_sum_of_multiple_of_9_is_always_9 = ",
+        "    property $ \\(n :: Integer) -> (n > 0) ==> (reducedDigitSum $ 9 * n) == 9"
+    );
+
+    @Input
+    @Option(option = "moduleName",
+           description = "The module name of the default frege file"
+    )
+    public abstract Property<String> getFregeModuleName();
+
+    @Internal
+    final Provider<String> getHelloFregeCode()
+    {
+        return getFregeModuleName()
+            .map(moduleName -> String.format("module %s where", moduleName))
+            .map(firstLine  -> String.join(
+                NEW_LINE, 
+                firstLine, HELLO_FREGE_CODE_WITHOUT_MODULE
+            ));
+    }
+
+    @Internal
+    final Provider<String> getFregeFilePath()
+    {
+        return getFregeModuleName()
+            .map(moduleName -> moduleName.replace(".", "/"))
+            .map(filePath   -> Paths.get(filePath).normalize())
+            .map(filePath   -> String.format("%s.fr", filePath.toString()));
+    }
+    
+    @OutputDirectory
+    public abstract DirectoryProperty getFregeMainSourceDir();
+
+    @OutputFile
+    final Provider<RegularFile> getHelloFregeFile()
+    {
+        return getFregeMainSourceDir().file(getFregeFilePath());
+    }
+
+    @TaskAction
+    public void writeHelloFregeFile() throws IOException
+    {
+        SharedTaskLogic.writeToFile(
+            getHelloFregeFile().get().getAsFile(),
+            getHelloFregeCode().get()
+        );
+    }
+}

--- a/src/main/java/ch/fhnw/thga/gradleplugins/SharedTaskLogic.java
+++ b/src/main/java/ch/fhnw/thga/gradleplugins/SharedTaskLogic.java
@@ -1,5 +1,10 @@
 package ch.fhnw.thga.gradleplugins;
 
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+
 import org.gradle.api.Project;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.provider.Provider;
@@ -8,6 +13,8 @@ import org.gradle.api.provider.Property;
 public final class SharedTaskLogic
 {
     private SharedTaskLogic() {};
+
+    public static final String NEW_LINE = System.lineSeparator();
 
     public static final Provider<FileCollection> setupClasspath(
         Project project,
@@ -21,8 +28,27 @@ public final class SharedTaskLogic
         });
     }
 
-   public static final String extractClassNameFromFregeModuleName(String moduleName)
-   {
+    public static final String extractClassNameFromFregeModuleName(String moduleName)
+    {
        return moduleName.substring(moduleName.lastIndexOf(".") + 1);
-   } 
+    }
+    
+    private static void writeFile(
+        File destination,
+        String content,
+        boolean append) 
+        throws IOException
+    {
+        try (BufferedWriter output = new BufferedWriter(new FileWriter(destination, append)))
+        {
+                output.write(content);
+        }
+    
+    }
+
+    static File writeToFile(File destination, String content) throws IOException
+    {
+        writeFile(destination, content, false);
+        return destination;
+    }
 }


### PR DESCRIPTION
Fixes: #28.

## New Feature
- **initFrege**: Creates a default `HelloFrege.fr` example file under
 `mainSource/examples/HelloFrege.fr`. Alternatively, you can specify the location
 on the command line with `--mainModule=my.mod.HelloFrege`.

## Fixes/Chores
- deleted obsolete test methods 
- reenabled the setupFregeTask test again
- minor cleanup in setupFregeTask