### PR TITLE
Frege Compiler Make Mode Test

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group = ch.fhnw.thga
-version = 2.0.1-alpha
+version = 2.0.2-alpha


### PR DESCRIPTION
Validates #https://github.com/tricktron/frege-lsp-server/issues/17.

The following applies if the frege compiler is run with the `-make`
[flag](https://github.com/Frege/frege/wiki/Compiler-Manpage#make-mode):
Given two dependent frege files. If the `mainSourceDir` property is not
correctly configured, then the frege compiler cannot find the dependent
frege file and will therefore fail the compilation.

The frege compiler starts at the `mainSourceDir` and searches
recursively for dependent modules. E.g. If `mod.Main.fr` imports `other.Dep.fr`
then the frege compilers searches for `mainSourceDir/other/Dep.fr`.