### PR TITLE
Add support for the frege-intellij plugin

### DIFF
--- a/example-project/build.gradle
+++ b/example-project/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'ch.fhnw.thga.frege' version '2.0.0-alpha'
+    id 'ch.fhnw.thga.frege' version 'latest'
 }
 
 frege {

--- a/example-project/build.gradle
+++ b/example-project/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'ch.fhnw.thga.frege' version 'latest'
+    id 'java'
 }
 
 frege {

--- a/example-project/settings.gradle
+++ b/example-project/settings.gradle
@@ -1,8 +1,13 @@
 pluginManagement {
-    repositories {
-        mavenLocal()
-        gradlePluginPortal()
+    resolutionStrategy {
+        eachPlugin {
+            if (requested.id.id == "ch.fhnw.thga.frege") {
+                var x = new Properties()
+                x.load(new FileInputStream(file("../gradle.properties")))
+                useVersion(x.get("version"))
+            }
+        }
     }
 }
-
 rootProject.name = 'example-project'
+includeBuild("..")

--- a/example-project/src/main/frege/ch/fhnw/thga/Hello2.fr
+++ b/example-project/src/main/frege/ch/fhnw/thga/Hello2.fr
@@ -1,0 +1,4 @@
+module ch.fhnw.thga.Hello2 where
+
+main args = do
+    putStrLn "Hello from File 2"

--- a/src/main/java/ch/fhnw/thga/gradleplugins/FregePlugin.java
+++ b/src/main/java/ch/fhnw/thga/gradleplugins/FregePlugin.java
@@ -13,6 +13,7 @@ public class FregePlugin implements Plugin<Project>
     public static final String SETUP_FREGE_TASK_NAME              = "setupFrege";
     public static final String COMPILE_FREGE_TASK_NAME            = "compileFrege";
     public static final String RUN_FREGE_TASK_NAME                = "runFrege";
+    public static final String RUN_FREGE_ALT_TASK_NAME            = "fregeRun";
     public static final String TEST_FREGE_TASK_NAME               = "testFrege";
     public static final String REPL_FREGE_TASK_NAME               = "replFrege";
     public static final String INIT_FREGE_TASK_NAME               = "initFrege";
@@ -22,6 +23,7 @@ public class FregePlugin implements Plugin<Project>
     public static final String HELLO_FREGE_DEFAULT_MODULE_NAME    = "examples.HelloFrege";
     public static final String FREGE_TEST_MODULE_NAME             = "frege.tools.Quick";
     public static final String FREGE_TEST_DEFAULT_ARGS            = "-v";
+    public static final String RUN_FREGE_TASK_MODULE_OVERRIDE     = "class_name"; // Used by the intellij-frege plugin to run arbitary files
 
     @Override
     public void apply(Project project)
@@ -36,13 +38,17 @@ public class FregePlugin implements Plugin<Project>
                         config.setCanBeConsumed(true);
                     }
             );
+        Configuration implementation = project.getConfigurations().maybeCreate("implementation");
+        NamedDomainObjectProvider<Configuration> fregeResolved = project.getConfigurations().register("fregeResolved");
+        implementation.extendsFrom(fregeConfiguration.get());
+        implementation.extendsFrom(fregeResolved.get());
 
         FregeExtension extension = project
             .getExtensions()
             .create(
             FREGE_EXTENSION_NAME,
             FregeExtension.class);
-        
+
         project.getPlugins().apply(BasePlugin.class);
 
         project.getTasks().register(
@@ -82,26 +88,33 @@ public class FregePlugin implements Plugin<Project>
                 }
             );
 
-        project.getTasks().register(
-            RUN_FREGE_TASK_NAME,
-            RunFregeTask.class,
-            task ->
-            {
-                task.getMainModule().set(extension.getMainModule());
-                task.dependsOn(compileFregeTask.map(
-                    compileTask ->
-                    {
-                        compileTask.getFregeCompileItem().set(task.getMainModule());
-                        return compileTask;
-                    }
-                ).get());
-                task.getFregeCompilerJar().set(
-                    setupFregeCompilerTask.get().getFregeCompilerOutputPath());
-                task.getFregeOutputDir().set(extension.getOutputDir());
-                task.getFregeDependencies().set(fregeConfiguration.get().getAsPath());
-            }
+        TaskProvider<RunFregeTask> runTask = project.getTasks().register(
+                RUN_FREGE_TASK_NAME,
+                RunFregeTask.class,
+                task ->
+                {
+                    if (project.hasProperty(RUN_FREGE_TASK_MODULE_OVERRIDE))
+                        task.getMainModule().set(project.findProperty(RUN_FREGE_TASK_MODULE_OVERRIDE).toString());
+                    else
+                        task.getMainModule().set(extension.getMainModule());
+                    task.dependsOn(compileFregeTask.map(
+                            compileTask ->
+                            {
+                                compileTask.getFregeCompileItem().set(task.getMainModule());
+                                return compileTask;
+                            }
+                    ).get());
+                    task.getFregeCompilerJar().set(
+                            setupFregeCompilerTask.get().getFregeCompilerOutputPath());
+                    task.getFregeOutputDir().set(extension.getOutputDir());
+                    task.getFregeDependencies().set(fregeConfiguration.get().getAsPath());
+                }
         );
-        
+
+        project.getTasks().register(RUN_FREGE_ALT_TASK_NAME, task -> {
+            task.dependsOn(runTask);
+        });
+
         project.getTasks().register(
             TEST_FREGE_TASK_NAME,
             TestFregeTask.class,
@@ -145,5 +158,8 @@ public class FregePlugin implements Plugin<Project>
                 task.getFregeMainSourceDir().set(extension.getMainSourceDir());
             }
         );
+        project.afterEvaluate(ignored -> {
+            project.getDependencies().add("implementation", setupFregeCompilerTask.map(SetupFregeTask::getFregeCompilerOutputPath).map(project::files));
+        });
     }
 }

--- a/src/main/java/ch/fhnw/thga/gradleplugins/FregePlugin.java
+++ b/src/main/java/ch/fhnw/thga/gradleplugins/FregePlugin.java
@@ -3,9 +3,12 @@ package ch.fhnw.thga.gradleplugins;
 import org.gradle.api.NamedDomainObjectProvider;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.logging.LogLevel;
 import org.gradle.api.plugins.BasePlugin;
+import org.gradle.api.plugins.JavaPluginExtension;
+import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.TaskProvider;
 
 public class FregePlugin implements Plugin<Project>
@@ -160,6 +163,18 @@ public class FregePlugin implements Plugin<Project>
         );
         project.afterEvaluate(ignored -> {
             project.getDependencies().add("implementation", setupFregeCompilerTask.map(SetupFregeTask::getFregeCompilerOutputPath).map(project::files));
+
+            JavaPluginExtension javaPluginExtension = project.getExtensions().findByType(JavaPluginExtension.class);
+            if(javaPluginExtension != null) {
+                SourceSet main = javaPluginExtension.getSourceSets().findByName("main");
+                if(main != null) {
+                    main.getOutput().dir(compileFregeTask.get().getOutputs());
+                }
+            }
+            Task classes = project.getTasks().findByName("classes");
+            if(classes != null) {
+                classes.dependsOn(compileFregeTask);
+            }
         });
     }
 }


### PR DESCRIPTION
This commit adds support for the frege intellij plugin by

 - exposing the frege compiler jar as a dependency, so the plugin can
   recognize the standard library.
 - adding the name 'fregeRun' as that is used by the plugin to run files
 - add support for overriding the main module executed by runFrege so
   that arbitary files can be run by the plugin
 - output frege compilation output into the java compilation output
   
 I'm reopening this PR, since it's now been rebased and i dont know how to switch HEAD branches in github.

As to why this PR is neccessary / addressing some of the questions asked in the last PR:

The intellij-frege plugin (https://github.com/IntelliJ-Frege/intellij-frege) uses a build.gradle that contains all the download+build+repl+etc code, and ive been using this plugin as a substitute for that. However, this plugin and the generated build.gradle have a few differences (mainly: `fregeRun` vs `runFrege`, and specifying the project property `class_name` to run a specific module when using the green run arrow), so i added those two changes to the `runFrege` task.

In addition to that i make both the frege jar and frege dependencies available on the java classpath, since that way they are per default included in the application plugin / shadow jar plugin and that way they are also indexed by intellij.

To that end, i also make the classes task depend on compileFrege so that frege compilation output is captured in the project jar. 