### PR TITLE
Suport Multiple Compile Items

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ file in your `build.gradle`:
 ```groovy
 plugins
 {
-    id 'ch.fhnw.thga.frege' version '1.9.0-alpha'
+    id 'ch.fhnw.thga.frege' version '3.0.0-alpha'
 }
 
 frege 
@@ -42,9 +42,10 @@ See the [Frege Releases](https://github.com/Frege/frege/releases) for all availa
 
 Optional configuration parameters inside `build.gradle`:
 - compilerDownloadDir: defaults to `<projectRoot>/lib`
-- mainSourceDir: defaults to `<projectRoot>/src/main/frege`
-- outputDir: defaults to `<projectRoot>/build/classes/main/frege`
-- compilerFlags: defaults to `['-O', '-make']`
+- mainSourceDir      : defaults to `<projectRoot>/src/main/frege`
+- outputDir          : defaults to `<projectRoot>/build/classes/main/frege`
+- compilerFlags      : defaults to `['-O', '-make']`
+- compileItems       : defaults to `[]`
 
 ### Added Tasks
 
@@ -53,9 +54,9 @@ Optional configuration parameters inside `build.gradle`:
  `mainSourceDir/examples/HelloFrege.fr`. Alternatively, you can specify the location
  on the command line with `--mainModule=my.mod.HelloFrege`.
 - **compileFrege**: Compiles all your `*.fr` files in `mainSourceDir` to `outputDir`.
-Alternatively, you can also pass the compile item by command line. Then only the
-compile item and its dependencies get compiled. 
-E.g.: `gradle compileFrege --compileItem=[full module name | absolute path to .fr file]`.
+Alternatively, you can also specify the compile items by with the `compileItems` property.
+Then only the specified compile items and its dependencies get compiled. 
+E.g.: `compileItems = [ 'my.mod.Mod1', my.mod.Mod2' ]`.
 - **runFrege**: Runs the Frege module specified by `mainModule`. Alternatively you can
 also pass the main module by command line, e.g: `gradle runFrege --mainModule=my.mod.Name`.
 - **testFrege**: Tests all QuickCheck properties defined in the specified `mainModule`.
@@ -71,7 +72,7 @@ On Unix you can even further automate starting the repl and loading the module
 ### Dependencies
 
 Dependencies can be configured as expected in your `build.gradle` file, using the
-`implementation` scope, e.g.:
+`frege` scope, e.g.:
 
 ```groovy
 repositories {
@@ -79,7 +80,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.frege-lang:fregefx:0.8.2-SNAPSHOT'
+    frege 'org.frege-lang:fregefx:0.8.2-SNAPSHOT'
 }
 ```
 
@@ -90,4 +91,6 @@ cache by setting `org.gradle.caching=true` in your `gradle.properites`.
 
 
 ## How to Contribute
-Try to add another task, e.g. `docFrege` to the [FregePluginFunctionalTest.java](src/functionalTest/java/ch/fhnw/thga/gradleplugins/FregePluginFunctionalTest.java) file and try to make the test pass.
+Try to add another task, e.g. `docFrege` to the 
+[FregePluginFunctionalTest.java](src/functionalTest/java/ch/fhnw/thga/gradleplugins/FregePluginFunctionalTest.java)
+file and try to make the test pass.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group = ch.fhnw.thga
-version = 3.0.0-alpha
+version = 3.0.1-alpha

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group = ch.fhnw.thga
-version = 3.0.1-alpha
+version = 3.0.2-alpha

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group = ch.fhnw.thga
-version = 2.0.2-alpha
+version = 3.0.0-alpha

--- a/src/functionalTest/java/ch/fhnw/thga/gradleplugins/CompileFregeTaskFunctionalTest.java
+++ b/src/functionalTest/java/ch/fhnw/thga/gradleplugins/CompileFregeTaskFunctionalTest.java
@@ -37,177 +37,199 @@ public class CompileFregeTaskFunctionalTest
         separator = " -> ",
         generator = DisplayNameGenerator.ReplaceUnderscores.class
     )
-    class Compile_frege_task_works {
-
+    class Compile_frege_task_works 
+    {
         @Test
-        void given_frege_code_in_default_source_dir_and_minimal_build_file_config(
-            @TempDir File testProjectDir)
-            throws Exception
+        void given_frege_code_in_default_source_dir_and_minimal_build_file_config
+            (@TempDir File testProjectDir) throws Exception
         {
             Project project = FregeProjectBuilder
-                .builder()
-                .projectRoot(testProjectDir)
-                .buildFile(MINIMAL_BUILD_FILE_CONFIG)
-                .fregeSourceFiles(() -> Stream.of(COMPLETION_FR))
-                .build();
+            .builder()
+            .projectRoot(testProjectDir)
+            .buildFile(MINIMAL_BUILD_FILE_CONFIG)
+            .fregeSourceFiles(() -> Stream.of(COMPLETION_FR))
+            .build();
             
             BuildResult result = runGradleTask(testProjectDir, COMPILE_FREGE_TASK_NAME);
 
-            assertTrue(
+            assertTrue
+            (
                 project
                 .getTasks()
                 .getByName(COMPILE_FREGE_TASK_NAME) 
                 instanceof CompileFregeTask
             );
-            assertEquals(
+            assertEquals
+            (
                 SUCCESS,
                 result.task(":" + COMPILE_FREGE_TASK_NAME).getOutcome()
             );
-            assertFileExists(
+            assertFileExists
+            (
                 testProjectDir,
                 "build/classes/main/frege/ch/fhnw/thga/Completion.java"
             );
-            assertFileExists(
+            assertFileExists
+            (
                 testProjectDir,
                 "build/classes/main/frege/ch/fhnw/thga/Completion.class"
             );
         }
 
         @Test
-        void given_frege_code_and_many_compiler_flags(
-            @TempDir File testProjectDir)
+        void given_frege_code_and_many_compiler_flags(@TempDir File testProjectDir)
             throws Exception
         {
-            String buildConfigWithCompilerFlags = createFregeSection(
+            String buildConfigWithCompilerFlags = createFregeSection
+            (
                 FregeDTOBuilder
-                .builder()
-                .version("'3.25.84'")
-                .release("'3.25alpha'")
+                .latestVersionBuilder()
                 .compilerFlags("['-v', '-make', '-O', '-hints']")
                 .build()
             );
             Project project = FregeProjectBuilder
-                .builder()
-                .projectRoot(testProjectDir)
-                .buildFile(buildConfigWithCompilerFlags)
-                .fregeSourceFiles(() -> Stream.of(COMPLETION_FR))
-                .build();
+            .builder()
+            .projectRoot(testProjectDir)
+            .buildFile(buildConfigWithCompilerFlags)
+            .fregeSourceFiles(() -> Stream.of(COMPLETION_FR))
+            .build();
             
             BuildResult result = runGradleTask(testProjectDir, COMPILE_FREGE_TASK_NAME);
 
-            assertTrue(
+            assertTrue
+            (
                 project
                 .getTasks()
                 .getByName(COMPILE_FREGE_TASK_NAME) 
                 instanceof CompileFregeTask
             );
-            assertEquals(
+            assertEquals
+            (
                 SUCCESS,
                 result.task(":" + COMPILE_FREGE_TASK_NAME).getOutcome()
             );
-            assertFileExists(
+            assertFileExists
+            (
                 testProjectDir,
                 "build/classes/main/frege/ch/fhnw/thga/Completion.java"
             );
-            assertFileExists(
+            assertFileExists
+            (
                 testProjectDir,
                 "build/classes/main/frege/ch/fhnw/thga/Completion.class"
             );
         }
 
         @Test
-        void given_frege_code_in_custom_source_and_output_dir_and_minimal_build_file_config(
-            @TempDir File testProjectDir)
+        void given_frege_code_in_custom_source_and_output_dir_and_minimal_build_file_config
+            (@TempDir File testProjectDir)
             throws Exception
         {
-            String customSourceAndOutputBuildFileConfig = createFregeSection(
+            String customSourceAndOutputBuildFileConfig = createFregeSection
+            (
                 FregeDTOBuilder
-                .builder()
-                .version("'3.25.84'")
-                .release("'3.25alpha'")
+                .latestVersionBuilder()
                 .mainSourceDir("layout.projectDirectory.dir('src/frege')")
                 .outputDir("layout.buildDirectory.dir('frege')")
                 .build()
             );
             Project project = FregeProjectBuilder
-                .builder()
-                .projectRoot(testProjectDir)
-                .buildFile(customSourceAndOutputBuildFileConfig)
-                .fregeSourceFiles(() -> Stream.of(new FregeSourceFile(
-                    "src/frege/ch/fhnw/thga/Completion.fr",
-                    COMPLETION_FR.getFregeSourceCode())))
-                .build();
+            .builder()
+            .projectRoot(testProjectDir)
+            .buildFile(customSourceAndOutputBuildFileConfig)
+            .fregeSourceFiles
+            (
+                () -> 
+                Stream.of
+                (
+                    new FregeSourceFile
+                    (
+                        "src/frege/ch/fhnw/thga/Completion.fr",
+                        COMPLETION_FR.getFregeSourceCode()
+                    )
+                )
+            )
+            .build();
 
             BuildResult result = runGradleTask(testProjectDir, COMPILE_FREGE_TASK_NAME);
-            assertTrue(
+            assertTrue
+            (
                 project
                 .getTasks()
                 .getByName(COMPILE_FREGE_TASK_NAME)
                 instanceof CompileFregeTask
             );
-            assertEquals(
+            assertEquals
+            (
                 SUCCESS,
                 result.task(":" + COMPILE_FREGE_TASK_NAME).getOutcome()
             );
-            assertFileExists(
+            assertFileExists
+            (
                 testProjectDir,
                 "build/frege/ch/fhnw/thga/Completion.java"
             );
-            assertFileExists(
+            assertFileExists
+            (
                 testProjectDir,
                 "build/frege/ch/fhnw/thga/Completion.class"
             );
         }
 
         @Test
-        void and_is_up_to_date_given_no_code_changes(
-            @TempDir File testProjectDir)
+        void and_is_up_to_date_given_no_code_changes(@TempDir File testProjectDir)
             throws Exception
         {
             FregeProjectBuilder
-                .builder()
-                .projectRoot(testProjectDir)
-                .buildFile(MINIMAL_BUILD_FILE_CONFIG)
-                .fregeSourceFiles(() -> Stream.of(COMPLETION_FR))
-                .build();
+            .builder()
+            .projectRoot(testProjectDir)
+            .buildFile(MINIMAL_BUILD_FILE_CONFIG)
+            .fregeSourceFiles(() -> Stream.of(COMPLETION_FR))
+            .build();
             
             BuildResult first = runGradleTask(testProjectDir, COMPILE_FREGE_TASK_NAME);
             
-            assertEquals(
+            assertEquals
+            (
                 SUCCESS, 
-                first.task(":" + COMPILE_FREGE_TASK_NAME).getOutcome());
+                first.task(":" + COMPILE_FREGE_TASK_NAME).getOutcome()
+            );
 
             BuildResult second = runGradleTask(testProjectDir, COMPILE_FREGE_TASK_NAME);
             
-            assertEquals(
+            assertEquals
+            (
                 UP_TO_DATE,
-                second.task(":" + COMPILE_FREGE_TASK_NAME).getOutcome());
+                second.task(":" + COMPILE_FREGE_TASK_NAME).getOutcome()
+            );
         }
         
         @Test
-        void and_is_cached_given_cache_hit(
-            @TempDir File testProjectDir) 
+        void and_is_cached_given_cache_hit(@TempDir File testProjectDir) 
             throws Exception 
         {
             FregeProjectBuilder
-                .builder()
-                .projectRoot(testProjectDir)
-                .buildFile(MINIMAL_BUILD_FILE_CONFIG)
-                .fregeSourceFiles(() -> Stream.of(COMPLETION_FR))
-                .build();
+            .builder()
+            .projectRoot(testProjectDir)
+            .buildFile(MINIMAL_BUILD_FILE_CONFIG)
+            .fregeSourceFiles(() -> Stream.of(COMPLETION_FR))
+            .build();
 
-            BuildResult first = runGradleTask(
+            BuildResult first = runGradleTask
+            (
                 testProjectDir,
                 COMPILE_FREGE_TASK_NAME,
                 "--build-cache"
             );
             
-            assertEquals(
+            assertEquals
+            (
                 SUCCESS, 
                 first.task(":" + COMPILE_FREGE_TASK_NAME).getOutcome()
             );
 
-            String codeChange = String.join(
+            String codeChange = String.join
+            (
                 NEW_LINE, 
                 "module ch.fhnw.thga.Completion where",
                 NEW_LINE,
@@ -218,48 +240,69 @@ public class CompileFregeTaskFunctionalTest
                 NEW_LINE
             );
             FregeProjectBuilder
-                .builder()
-                .projectRoot(testProjectDir)
-                .buildFile(MINIMAL_BUILD_FILE_CONFIG)
-                .fregeSourceFiles(() -> Stream.of(new FregeSourceFile(
-                    COMPLETION_FR.getFregeModulePath(),
-                    codeChange)))
-                .build();
+            .builder()
+            .projectRoot(testProjectDir)
+            .buildFile(MINIMAL_BUILD_FILE_CONFIG)
+            .fregeSourceFiles
+            (
+                () -> 
+                Stream.of
+                (
+                    new FregeSourceFile
+                    (
+                        COMPLETION_FR.getFregeModulePath(),
+                        codeChange
+                    )
+                )
+            )
+            .build();
 
-            BuildResult second = runGradleTask(
+            BuildResult second = runGradleTask
+            (
                 testProjectDir,
                 COMPILE_FREGE_TASK_NAME,
                 "--build-cache"
             );
             
-            assertEquals(
+            assertEquals
+            (
                 SUCCESS,
                 second.task(":" + COMPILE_FREGE_TASK_NAME).getOutcome()
             );
 
             FregeProjectBuilder
-                .builder()
-                .projectRoot(testProjectDir)
-                .buildFile(MINIMAL_BUILD_FILE_CONFIG)
-                .fregeSourceFiles(() -> Stream.of(COMPLETION_FR))
-                .build();
-            BuildResult third = runGradleTask(
+            .builder()
+            .projectRoot(testProjectDir)
+            .buildFile(MINIMAL_BUILD_FILE_CONFIG)
+            .fregeSourceFiles(() -> Stream.of(COMPLETION_FR))
+            .build();
+            BuildResult third = runGradleTask
+            (
                 testProjectDir,
                 COMPILE_FREGE_TASK_NAME,
                 "--build-cache"
             );
             
-            assertEquals(
+            assertEquals
+            (
                 FROM_CACHE, 
-                third.task(":" + COMPILE_FREGE_TASK_NAME).getOutcome());
+                third.task(":" + COMPILE_FREGE_TASK_NAME).getOutcome()
+            );
         }
         
         @Test
-        void given_two_dependent_frege_files_in_default_source_dir_and_minimal_build_file_config(
-            @TempDir File testProjectDir)
+        void given_two_dependent_frege_files_in_default_source_dir_and_correct_main_module_specified
+            (@TempDir File testProjectDir)
             throws Exception
         {
-            String frobCode = String.join(
+            String buildFileConfigWithMainModule = createFregeSection
+            (
+                FregeDTOBuilder.latestVersionBuilder()
+                .compileItems("['ch.fhnw.thga.Frob']")
+                .build()
+            );
+            String frobCode = String.join
+            (
                 NEW_LINE,
                 "module ch.fhnw.thga.Frob where",
                 NEW_LINE,
@@ -271,47 +314,64 @@ public class CompileFregeTaskFunctionalTest
             );
             
             Project project = FregeProjectBuilder
-                .builder()
-                .projectRoot(testProjectDir)
-                .buildFile(MINIMAL_BUILD_FILE_CONFIG)
-                .fregeSourceFiles(() -> Stream.of(COMPLETION_FR, new FregeSourceFile(
-                    String.format(
-                        "%s/%s",
-                        DEFAULT_RELATIVE_SOURCE_DIR,
-                        "ch/fhnw/thga/Frob.fr"
-                    ),
-                    frobCode)))
-                .build();
-            
-            BuildResult result = runGradleTask(
+            .builder()
+            .projectRoot(testProjectDir)
+            .buildFile(buildFileConfigWithMainModule)
+            .fregeSourceFiles
+            (
+                () -> 
+                Stream.of
+                (
+                    COMPLETION_FR, 
+                    new FregeSourceFile
+                    (
+                        String.format
+                        (
+                            "%s/%s", 
+                            DEFAULT_RELATIVE_SOURCE_DIR,
+                            "ch/fhnw/thga/Frob.fr"
+                        ),
+                        frobCode
+                    )
+                )
+            )
+            .build();
+
+            BuildResult result = runGradleTask
+            (
                 testProjectDir,
-                COMPILE_FREGE_TASK_NAME,
-                "--compileItem=ch.fhnw.thga.Frob"
+                COMPILE_FREGE_TASK_NAME
             );
 
-            assertTrue(
+            assertTrue
+            (
                 project
                 .getTasks()
                 .getByName(COMPILE_FREGE_TASK_NAME) 
                 instanceof CompileFregeTask
             );
-            assertEquals(
+            assertEquals
+            (
                 SUCCESS,
                 result.task(":" + COMPILE_FREGE_TASK_NAME).getOutcome()
             );
-            assertFileExists(
+            assertFileExists
+            (
                 testProjectDir,
                 "build/classes/main/frege/ch/fhnw/thga/Completion.java"
             );
-            assertFileExists(
+            assertFileExists
+            (
                 testProjectDir,
                 "build/classes/main/frege/ch/fhnw/thga/Completion.class"
             );
-            assertFileExists(
+            assertFileExists
+            (
                 testProjectDir,
                 "build/classes/main/frege/ch/fhnw/thga/Frob.java"
             );
-            assertFileExists(
+            assertFileExists
+            (
                 testProjectDir,
                 "build/classes/main/frege/ch/fhnw/thga/Frob.class"
             );
@@ -319,106 +379,126 @@ public class CompileFregeTaskFunctionalTest
     }
 
     @Nested
-    @IndicativeSentencesGeneration(
+    @IndicativeSentencesGeneration
+    (
         separator = " -> ",
         generator = DisplayNameGenerator.ReplaceUnderscores.class
     )
     class Compile_frege_task_fails
     {
         @Test
-        void given_frege_code_and_illegal_compiler_flags(
-            @TempDir File testProjectDir)
+        void given_frege_code_and_illegal_compiler_flags
+            (@TempDir File testProjectDir)
             throws Exception
         {
-            String buildConfigWithIllegalCompilerFlags = createFregeSection(
+            String buildConfigWithIllegalCompilerFlags = createFregeSection
+            (
                 FregeDTOBuilder
-                .builder()
-                .version("'3.25.84'")
-                .release("'3.25alpha'")
+                .latestVersionBuilder()
                 .compilerFlags("['-make', '-bla']")
                 .build()
             );
             Project project = FregeProjectBuilder
-                .builder()
-                .projectRoot(testProjectDir)
-                .buildFile(buildConfigWithIllegalCompilerFlags)
-                .fregeSourceFiles(() -> Stream.of(COMPLETION_FR))
-                .build();
+            .builder()
+            .projectRoot(testProjectDir)
+            .buildFile(buildConfigWithIllegalCompilerFlags)
+            .fregeSourceFiles(() -> Stream.of(COMPLETION_FR))
+            .build();
 
-            BuildResult result = runAndFailGradleTask(testProjectDir, COMPILE_FREGE_TASK_NAME);
+            BuildResult result = runAndFailGradleTask
+            (
+                testProjectDir, 
+                COMPILE_FREGE_TASK_NAME
+            );
 
-            assertTrue(
+            assertTrue
+            (
                 project
                 .getTasks()
                 .getByName(COMPILE_FREGE_TASK_NAME)
                 instanceof CompileFregeTask
             );
-            assertEquals(
+            assertEquals
+            (
                 FAILED, 
                 result.task(":" + COMPILE_FREGE_TASK_NAME).getOutcome()
             );
         }
         
         @Test
-        void given_two_dependent_frege_files_in_default_source_dir_and_without_make_compiler_flag(
-            @TempDir File testProjectDir)
+        void given_two_dependent_frege_files_in_default_source_dir_and_without_make_compiler_flag
+            (@TempDir File testProjectDir)
             throws Exception
         {
-            String frobCode = String.join(
-            NEW_LINE,
-            "module ch.fhnw.thga.Frob where",
-            NEW_LINE,
-            NEW_LINE,
-            "import ch.fhnw.thga.Completion (complete)",
-            NEW_LINE,
-            "frob i = complete $ i + i",
-            NEW_LINE
+            String frobCode = String.join
+            (
+                NEW_LINE,
+                "module ch.fhnw.thga.Frob where",
+                NEW_LINE,
+                NEW_LINE,
+                "import ch.fhnw.thga.Completion (complete)",
+                NEW_LINE,
+                "frob i = complete $ i + i",
+                NEW_LINE
             );
-            String minimalBuildFileConfigWithoutMake = createFregeSection(
-                FregeDTOBuilder
-                .builder()
-                .version("'3.25.84'")
-                .release("'3.25alpha'")
+            String minimalBuildFileConfigWithoutMake = createFregeSection
+            (
+                FregeDTOBuilder.latestVersionBuilder()
                 .compilerFlags("['-v']")
+                .compileItems("['ch.fhnw.thga.Frob']")
                 .build()
             );
             Project project = FregeProjectBuilder
-                .builder()
-                .projectRoot(testProjectDir)
-                .buildFile(minimalBuildFileConfigWithoutMake)
-                .fregeSourceFiles(() -> Stream.of(COMPLETION_FR, new FregeSourceFile(
-                    String.format(
-                        "%s/%s",
-                        DEFAULT_RELATIVE_SOURCE_DIR,
-                        "ch/fhnw/thga/Frob.fr"
-                    ),
-                    frobCode)))
-                .build();
+            .builder()
+            .projectRoot(testProjectDir)
+            .buildFile(minimalBuildFileConfigWithoutMake)
+            .fregeSourceFiles
+            (
+                () -> 
+                Stream.of
+                (
+                    COMPLETION_FR, 
+                    new FregeSourceFile
+                    (
+                        String.format
+                        (
+                            "%s/%s",
+                            DEFAULT_RELATIVE_SOURCE_DIR,
+                            "ch/fhnw/thga/Frob.fr"
+                        ),
+                        frobCode
+                    )
+                )
+            )
+            .build();
             
-            BuildResult result = runAndFailGradleTask(
+            BuildResult result = runAndFailGradleTask
+            (
                 testProjectDir,
-                COMPILE_FREGE_TASK_NAME,
-                "--compileItem=ch.fhnw.thga.Frob"
+                COMPILE_FREGE_TASK_NAME
             );
 
-            assertTrue(
+            assertTrue
+            (
                 project
                 .getTasks()
                 .getByName(COMPILE_FREGE_TASK_NAME) 
                 instanceof CompileFregeTask
             );
-            assertEquals(
+            assertEquals
+            (
                 FAILED, 
                 result.task(":" + COMPILE_FREGE_TASK_NAME).getOutcome()
             );
         }
 
         @Test
-        void given_wrong_main_source_dir_when_searching_for_dependent_frege_module(
-            @TempDir File testProjectDir)
+        void given_wrong_main_source_dir_when_searching_for_dependent_frege_module
+            (@TempDir File testProjectDir)
             throws Exception
         {
-            String codeImportingDependentModule = String.join(
+            String codeImportingDependentModule = String.join
+            (
                 NEW_LINE,
                 "module ch.fhnw.thga.Frob where",
                 NEW_LINE,
@@ -429,41 +509,54 @@ public class CompileFregeTaskFunctionalTest
                 NEW_LINE
             );
 
-            String wrongMainSourceDirBuildFileConfig = createFregeSection(
+            String wrongMainSourceDirBuildFileConfig = createFregeSection
+            (
                 FregeDTOBuilder
-                .builder()
-                .version("'3.25.84'")
-                .release("'3.25alpha'")
+                .latestVersionBuilder()
                 .mainSourceDir("layout.projectDirectory")
+                .compileItems("['ch.fhnw.thga.Frob']")
                 .build()
             );
-            
+
             Project project = FregeProjectBuilder
-                .builder()
-                .projectRoot(testProjectDir)
-                .buildFile(wrongMainSourceDirBuildFileConfig)
-                .fregeSourceFiles(() -> Stream.of(COMPLETION_FR, new FregeSourceFile(
-                    String.format(
-                        "%s/%s",
-                        DEFAULT_RELATIVE_SOURCE_DIR,
-                        "ch/fhnw/thga/Frob.fr"
-                    ),
-                    codeImportingDependentModule)))
-                .build();
-            
-            BuildResult result = runAndFailGradleTask(
+            .builder()
+            .projectRoot(testProjectDir)
+            .buildFile(wrongMainSourceDirBuildFileConfig)
+            .fregeSourceFiles
+            (
+                () -> 
+                Stream.of
+                (
+                    COMPLETION_FR, 
+                    new FregeSourceFile
+                    (
+                        String.format
+                        (
+                            "%s/%s",
+                            DEFAULT_RELATIVE_SOURCE_DIR,
+                            "ch/fhnw/thga/Frob.fr"
+                        ),
+                        codeImportingDependentModule
+                    )
+                )
+            )
+            .build();
+
+            BuildResult result = runAndFailGradleTask
+            (
                 testProjectDir,
-                COMPILE_FREGE_TASK_NAME,
-                "--compileItem=ch.fhnw.thga.Frob"
+                COMPILE_FREGE_TASK_NAME
             );
 
-            assertTrue(
+            assertTrue
+            (
                 project
                 .getTasks()
                 .getByName(COMPILE_FREGE_TASK_NAME) 
                 instanceof CompileFregeTask
             );
-            assertEquals(
+            assertEquals
+            (
                 FAILED,
                 result.task(":" + COMPILE_FREGE_TASK_NAME).getOutcome()
             );

--- a/src/functionalTest/java/ch/fhnw/thga/gradleplugins/ReplFregeTaskFunctionalTest.java
+++ b/src/functionalTest/java/ch/fhnw/thga/gradleplugins/ReplFregeTaskFunctionalTest.java
@@ -2,6 +2,7 @@ package ch.fhnw.thga.gradleplugins;
 
 import static ch.fhnw.thga.gradleplugins.FregeExtension.DEFAULT_RELATIVE_SOURCE_DIR;
 import static ch.fhnw.thga.gradleplugins.FregePlugin.REPL_FREGE_TASK_NAME;
+import static ch.fhnw.thga.gradleplugins.FregePlugin.COMPILE_FREGE_TASK_NAME;
 import static ch.fhnw.thga.gradleplugins.SharedFunctionalTestLogic.COMPLETION_FR;
 import static ch.fhnw.thga.gradleplugins.SharedFunctionalTestLogic.MINIMAL_BUILD_FILE_CONFIG;
 import static ch.fhnw.thga.gradleplugins.SharedTaskLogic.NEW_LINE;
@@ -166,17 +167,23 @@ public class ReplFregeTaskFunctionalTest
                 .fregeSourceFiles(() -> Stream.of(COMPLETION_FR))
                 .build();
                                                                                          
-            BuildResult result = runAndFailGradleTask(testProjectDir, REPL_FREGE_TASK_NAME);
+            BuildResult result = runAndFailGradleTask
+            (
+                testProjectDir, 
+                REPL_FREGE_TASK_NAME
+            );
 
-            assertTrue(
+            assertTrue
+            (
                 project
                 .getTasks()
                 .getByName(REPL_FREGE_TASK_NAME)
                 instanceof ReplFregeTask
             );
-            assertEquals(
+            assertEquals
+            (
                 FAILED,
-                result.task(":" + REPL_FREGE_TASK_NAME).getOutcome()
+                result.task(":" + COMPILE_FREGE_TASK_NAME).getOutcome()
             );
         }
     }

--- a/src/functionalTest/java/ch/fhnw/thga/gradleplugins/ReplFregeTaskFunctionalTest.java
+++ b/src/functionalTest/java/ch/fhnw/thga/gradleplugins/ReplFregeTaskFunctionalTest.java
@@ -34,61 +34,70 @@ import ch.fhnw.thga.gradleplugins.fregeproject.FregeSourceFile;
 public class ReplFregeTaskFunctionalTest
 {
     @Nested
-    @IndicativeSentencesGeneration(
-        generator = DisplayNameGenerator.ReplaceUnderscores.class)
+    @IndicativeSentencesGeneration
+    (generator = DisplayNameGenerator.ReplaceUnderscores.class)
     class Repl_frege_task_works
     {
         @Test
-        void given_minimal_build_file_config_with_repl_module(
-            @TempDir File testProjectDir)
+        void given_minimal_build_file_config_with_repl_module
+            (@TempDir File testProjectDir)
             throws Exception
         {
-            String replModuleConfig = createFregeSection(
+            String replModuleConfig = createFregeSection
+            (
                 FregeDTOBuilder
-                .builder()
-                .version("'3.25.84'")
-                .release("'3.25alpha'")
+                .latestVersionBuilder()
                 .replModule("'ch.fhnw.thga.Completion'")
                 .build()
             );
             Project project = FregeProjectBuilder
-                .builder()
-                .projectRoot(testProjectDir)
-                .buildFile(replModuleConfig)
-                .fregeSourceFiles(() -> Stream.of(COMPLETION_FR))
-                .build();
+            .builder()
+            .projectRoot(testProjectDir)
+            .buildFile(replModuleConfig)
+            .fregeSourceFiles(() -> Stream.of(COMPLETION_FR))
+            .build();
                                                                                          
             BuildResult result = runGradleTask(testProjectDir, REPL_FREGE_TASK_NAME);
                                                                                          
-            assertTrue(
+            assertTrue
+            (
                 project
                 .getTasks()
                 .getByName(REPL_FREGE_TASK_NAME)
-                instanceof ReplFregeTask);
-            assertEquals(
+                instanceof ReplFregeTask
+            );
+            assertEquals
+            (
                 SUCCESS,
-                result.task(":" + REPL_FREGE_TASK_NAME).getOutcome());
+                result.task(":" + REPL_FREGE_TASK_NAME).getOutcome()
+            );
             assertTrue(result.getOutput().contains("java -cp"));
             assertTrue(result.getOutput().contains("frege3.25.84.jar"));
-            assertTrue(result.getOutput().contains(
-                Paths.get(COMPLETION_FR.getFregeModulePath()).normalize().toString())
+            assertTrue
+            (
+                result
+                .getOutput()
+                .contains(Paths.get(COMPLETION_FR.getFregeModulePath()).normalize().toString())
             );
-            assertFileDoesNotExist(
+            assertFileDoesNotExist
+            (
                 testProjectDir,
                 "build/classes/main/frege/ch/fhnw/thga/Completion.java"
             );
-            assertFileDoesNotExist(
+            assertFileDoesNotExist
+            (
                 testProjectDir,
                 "build/classes/main/frege/ch/fhnw/thga/Completion.class"
             );
         }
 
         @Test
-        void given_dependent_frege_files_with_command_line_repl_module_option(
-            @TempDir File testProjectDir)
+        void given_dependent_frege_files_with_command_line_repl_module_option
+            (@TempDir File testProjectDir)
             throws Exception
         {
-            String frobCode = String.join(
+            String frobCode = String.join
+            (
                 NEW_LINE,
                 "module ch.fhnw.thga.Frob where",
                 NEW_LINE,
@@ -98,74 +107,158 @@ public class ReplFregeTaskFunctionalTest
                 "frob i = complete $ i + i",
                 NEW_LINE
             );
-            FregeSourceFile frob_FR = new FregeSourceFile(
-                String.format(
+            FregeSourceFile frob_FR = new FregeSourceFile
+            (
+                String.format
+                (
                     "%s/%s",
                     DEFAULT_RELATIVE_SOURCE_DIR,
                     "ch/fhnw/thga/Frob.fr"
                 ),
-                frobCode);
+                frobCode
+            );
             Project project = FregeProjectBuilder
-                .builder()
-                .projectRoot(testProjectDir)
-                .buildFile(MINIMAL_BUILD_FILE_CONFIG)
-                .fregeSourceFiles(() -> Stream.of(COMPLETION_FR, frob_FR))
-                .build();
+            .builder()
+            .projectRoot(testProjectDir)
+            .buildFile(MINIMAL_BUILD_FILE_CONFIG)
+            .fregeSourceFiles(() -> Stream.of(COMPLETION_FR, frob_FR))
+            .build();
             
-            BuildResult result = runGradleTask(
+            BuildResult result = runGradleTask
+            (
                 testProjectDir,
                 REPL_FREGE_TASK_NAME,
                 "--replModule=ch.fhnw.thga.Frob"
             );
             
-            assertTrue(
+            assertTrue
+            (
                 project
                 .getTasks()
                 .getByName(REPL_FREGE_TASK_NAME)
-                instanceof ReplFregeTask);
-            assertEquals(
+                instanceof ReplFregeTask
+            );
+            assertEquals
+            (
                 SUCCESS,
-                result.task(":" + REPL_FREGE_TASK_NAME).getOutcome());
+                result.task(":" + REPL_FREGE_TASK_NAME).getOutcome()
+            );
             assertTrue(result.getOutput().contains("java -cp"));
             assertTrue(result.getOutput().contains("frege3.25.84.jar"));
-            assertTrue(result.getOutput().contains(
-                Paths.get(frob_FR.getFregeModulePath()).normalize().toString())
+            assertTrue
+            (
+                result
+                .getOutput()
+                .contains(Paths.get(frob_FR.getFregeModulePath()).normalize().toString())
             );
-            assertFileExists(
+            assertFileExists
+            (
                 testProjectDir,
                 "build/classes/main/frege/ch/fhnw/thga/Completion.java"
             );
-            assertFileExists(
+            assertFileExists
+            (
                 testProjectDir,
                 "build/classes/main/frege/ch/fhnw/thga/Completion.class"
             );
-            assertFileDoesNotExist(
+            assertFileDoesNotExist
+            (
                 testProjectDir,
                 "build/classes/main/frege/ch/fhnw/thga/Frob.java"
             );
-            assertFileDoesNotExist(
+            assertFileDoesNotExist
+            (
                 testProjectDir,
                 "build/classes/main/frege/ch/fhnw/thga/Frob.class"
+            );
+        }
+        @Test
+        void given_a_correct_repl_module_and_an_indepedent_frege_file_with_errors
+            (@TempDir File testProjectDir)
+            throws Exception
+        {
+            String frobWithErrors = String.join
+            (
+                NEW_LINE,
+                "module ch.fhnw.thga.FrobWithErrors where",
+                NEW_LINE,
+                NEW_LINE,
+                "errAddingIntWithString = 42 + \"42\"",
+                NEW_LINE
+            );
+            FregeSourceFile frobWithErrors_FR = new FregeSourceFile
+            (
+                String.format
+                (
+                    "%s/%s",
+                    DEFAULT_RELATIVE_SOURCE_DIR,
+                    "ch/fhnw/thga/FrobWithErrors.fr"
+                ),
+                frobWithErrors
+            );
+            Project project = FregeProjectBuilder
+            .builder()
+            .projectRoot(testProjectDir)
+            .buildFile(MINIMAL_BUILD_FILE_CONFIG)
+            .fregeSourceFiles(() -> Stream.of(COMPLETION_FR, frobWithErrors_FR))
+            .build();
+            
+            BuildResult result = runGradleTask
+            (
+                testProjectDir,
+                REPL_FREGE_TASK_NAME,
+                "--replModule=ch.fhnw.thga.Completion"
+            );
+            
+            assertTrue
+            (
+                project
+                .getTasks()
+                .getByName(REPL_FREGE_TASK_NAME)
+                instanceof ReplFregeTask
+            );
+            assertEquals
+            (
+                SUCCESS,
+                result.task(":" + REPL_FREGE_TASK_NAME).getOutcome()
+            );
+            assertTrue(result.getOutput().contains("java -cp"));
+            assertTrue(result.getOutput().contains("frege3.25.84.jar"));
+            assertTrue
+            (
+                result
+                .getOutput()
+                .contains(Paths.get(COMPLETION_FR.getFregeModulePath()).normalize().toString())
+            );
+            assertFileDoesNotExist
+            (
+                testProjectDir,
+                "build/classes/main/frege/ch/fhnw/thga/Completion.java"
+            );
+            assertFileDoesNotExist
+            (
+                testProjectDir,
+                "build/classes/main/frege/ch/fhnw/thga/Completion.class"
             );
         }
     }
 
     @Nested
-    @IndicativeSentencesGeneration(
-        generator = DisplayNameGenerator.ReplaceUnderscores.class)
+    @IndicativeSentencesGeneration
+    (generator = DisplayNameGenerator.ReplaceUnderscores.class)
     class Repl_frege_task_fails
     {
         @Test
-        void given_minimal_build_file_config_without_repl_module(
-            @TempDir File testProjectDir)
+        void given_minimal_build_file_config_without_repl_module
+            (@TempDir File testProjectDir)
             throws Exception
         {
             Project project = FregeProjectBuilder
-                .builder()
-                .projectRoot(testProjectDir)
-                .buildFile(MINIMAL_BUILD_FILE_CONFIG)
-                .fregeSourceFiles(() -> Stream.of(COMPLETION_FR))
-                .build();
+            .builder()
+            .projectRoot(testProjectDir)
+            .buildFile(MINIMAL_BUILD_FILE_CONFIG)
+            .fregeSourceFiles(() -> Stream.of(COMPLETION_FR))
+            .build();
                                                                                          
             BuildResult result = runAndFailGradleTask
             (

--- a/src/main/java/ch/fhnw/thga/gradleplugins/FregeExtension.java
+++ b/src/main/java/ch/fhnw/thga/gradleplugins/FregeExtension.java
@@ -1,5 +1,6 @@
 package ch.fhnw.thga.gradleplugins;
 
+import java.util.Collections;
 import java.util.List;
 
 import javax.inject.Inject;
@@ -15,6 +16,7 @@ public abstract class FregeExtension
     public static final String DEFAULT_RELATIVE_OUTPUT_DIR              = "classes/main/frege";
     public static final String DEFAULT_RELATIVE_SOURCE_DIR              = "src/main/frege";
     public static final List<String> DEFAULT_COMPILER_FLAGS             = List.of("-O", "-make");
+    public static final List<String> DEFAULT_COMPILE_ITEMS              = Collections.emptyList();
 
     public abstract Property<String> getVersion();
 
@@ -32,6 +34,8 @@ public abstract class FregeExtension
 
     public abstract Property<String> getReplModule();
 
+    public abstract ListProperty<String> getCompileItems();
+
     @Inject
     public FregeExtension(ProjectLayout projectLayout)
     {
@@ -45,5 +49,7 @@ public abstract class FregeExtension
         .convention(projectLayout.getBuildDirectory().dir(DEFAULT_RELATIVE_OUTPUT_DIR));
 
         getCompilerFlags().convention(DEFAULT_COMPILER_FLAGS);
+
+        getCompileItems().convention(DEFAULT_COMPILE_ITEMS);
     }
 }

--- a/src/main/java/ch/fhnw/thga/gradleplugins/ReplFregeTask.java
+++ b/src/main/java/ch/fhnw/thga/gradleplugins/ReplFregeTask.java
@@ -107,4 +107,4 @@ public abstract class ReplFregeTask extends DefaultTask
             )
         );
     }
-q
+}

--- a/src/main/java/ch/fhnw/thga/gradleplugins/ReplFregeTask.java
+++ b/src/main/java/ch/fhnw/thga/gradleplugins/ReplFregeTask.java
@@ -16,9 +16,12 @@ import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.options.Option;
 
-public abstract class ReplFregeTask extends DefaultTask {
-    private static final Logger LOGGER         = Logging.getLogger(ReplFregeTask.class);
-    public static final String REPL_MAIN_CLASS = "frege.repl.FregeRepl";
+public abstract class ReplFregeTask extends DefaultTask 
+{
+    private static final Logger LOGGER             = Logging.getLogger(ReplFregeTask.class);
+    public static final String REPL_MAIN_CLASS     = "frege.repl.FregeRepl";
+    private static final String REPL_START_MESSAGE = 
+    "Execute the following command to start the Frege Repl and load the Frege module:";
 
     @InputFile
     public abstract RegularFileProperty getFregeCompilerJar();
@@ -33,8 +36,11 @@ public abstract class ReplFregeTask extends DefaultTask {
     public abstract DirectoryProperty getFregeMainSourceDir();
 
     @Input
-    @Option(option     = "replModule",
-           description = "The full name of the module which you want to load into the repl, e.g. 'my.mod.Name'")
+    @Option
+    (
+        option      = "replModule",
+        description = "The full name of the module which you want to load into the repl, e.g. 'my.mod.Name'"
+    )
     public abstract Property<String> getReplModule();
 
     @Internal
@@ -44,49 +50,37 @@ public abstract class ReplFregeTask extends DefaultTask {
             .map(replSource -> extractClassNameFromFregeModuleName(replSource));
     }
 
+    private final Provider<FileTree> filterFilesBySuffix
+        (DirectoryProperty root, String suffix)
+    {
+        return root
+        .zip
+        (
+            getReplClassName(), 
+            (rootDir, replClassname) ->
+                rootDir
+                .getAsFileTree()
+                .matching
+                (pattern -> pattern.include(String.format("**/%s.%s", replClassname, suffix)))
+        ); 
+    }
+
     @Internal
     public final Provider<FileTree> getReplClassFiles()
     {
-        return getFregeOutputDir()
-            .map(outDir -> outDir.getAsFileTree())
-            .map(tree   -> tree.matching(
-                pattern -> pattern.include(
-                    String.format(
-                        "**/%s.class",
-                        getReplClassName().get()
-                    )
-                )
-            ));
+        return filterFilesBySuffix(getFregeOutputDir(), "class");
     }
 
     @Internal
     public final Provider<FileTree> getReplJavaFiles()
     {
-        return getFregeOutputDir()
-            .map(outDir -> outDir.getAsFileTree())
-            .map(tree   -> tree.matching(
-                pattern -> pattern.include(
-                    String.format(
-                        "**/%s.java",
-                        getReplClassName().get()
-                    )
-                ))
-            );
+        return filterFilesBySuffix(getFregeOutputDir(), "java");
     }
 
     @Internal
     public final Provider<FileTree> getReplFregeFile()
     {
-        return getFregeMainSourceDir()
-            .map(outDir -> outDir.getAsFileTree())
-            .map(tree   -> tree.matching(
-                pattern -> pattern.include(
-                    String.format(
-                        "**/%s.fr",
-                        getReplClassName().get()
-                    )
-                ))
-            );
+        return filterFilesBySuffix(getFregeMainSourceDir(), "fr");
     }
 
     @TaskAction
@@ -94,18 +88,23 @@ public abstract class ReplFregeTask extends DefaultTask {
     {
         getProject().delete(getReplJavaFiles());
         getProject().delete(getReplClassFiles());
-        LOGGER.lifecycle(
-            "Execute the following command to start the Frege Repl and load the Frege module:");
-        LOGGER.quiet(String.format(
-            "(echo :l %s && cat) | java -cp %s %s",
-            getReplFregeFile().get().getAsPath(),
-            SharedTaskLogic.setupClasspath(
-                getProject(),
-                getFregeDependencies(),
-                getFregeCompilerJar(),
-                getFregeOutputDir())
-            .get().getAsPath(),
-            REPL_MAIN_CLASS)
+        LOGGER.lifecycle(REPL_START_MESSAGE);
+        LOGGER.quiet
+        (
+            String.format
+            (
+                "(echo :l %s && cat) | java -cp %s %s",
+                getReplFregeFile().get().getAsPath(),
+                SharedTaskLogic.setupClasspath
+                (
+                    getProject(),
+                    getFregeDependencies(),
+                    getFregeCompilerJar(),
+                    getFregeOutputDir()
+                )
+                .get().getAsPath(),
+                REPL_MAIN_CLASS
+            )
         );
     }
-}
+q

--- a/src/test/java/ch/fhnw/thga/gradleplugins/Builder.java
+++ b/src/test/java/ch/fhnw/thga/gradleplugins/Builder.java
@@ -1,6 +1,7 @@
 package ch.fhnw.thga.gradleplugins;
 
-public interface Builder {
+public interface Builder 
+{
     Builder version(String version);
 
     Builder release(String release);
@@ -16,6 +17,8 @@ public interface Builder {
     Builder compilerFlags(String compilerFlags);
 
     Builder replModule(String replModule);
+    
+    Builder compileItems(String compileItems);
 
     FregeDTO build();
 }

--- a/src/test/java/ch/fhnw/thga/gradleplugins/FregeDTO.java
+++ b/src/test/java/ch/fhnw/thga/gradleplugins/FregeDTO.java
@@ -6,7 +6,8 @@ import java.util.Arrays;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-public class FregeDTO {
+public class FregeDTO 
+{
     public final String version;
     public final String release;
     public final String compilerDownloadDir;
@@ -15,104 +16,139 @@ public class FregeDTO {
     public final String mainModule;
     public final String compilerFlags;
     public final String replModule;
+    public final String compileItems;
 
-    public FregeDTO(
-        String version,
-        String release,
-        String compilerDownloadDir,
-        String mainSourceDir,
-        String outputDir,
-        String mainModule,
-        String compilerFlags,
-        String replModule) {
-        this.version = version;
-        this.release = release;
+    public FregeDTO
+        (
+            String version,
+            String release,
+            String compilerDownloadDir,
+            String mainSourceDir,
+            String outputDir,
+            String mainModule,
+            String compilerFlags,
+            String replModule,
+            String compileItems
+        ) 
+    {
+        this.version             = version;
+        this.release             = release;
         this.compilerDownloadDir = compilerDownloadDir;
-        this.mainSourceDir = mainSourceDir;
-        this.outputDir = outputDir;
-        this.mainModule = mainModule;
-        this.compilerFlags = compilerFlags;
-        this.replModule = replModule;
+        this.mainSourceDir       = mainSourceDir;
+        this.outputDir           = outputDir;
+        this.mainModule          = mainModule;
+        this.compilerFlags       = compilerFlags;
+        this.replModule          = replModule;
+        this.compileItems        = compileItems;
     }
 
-    public String getVersion() {
+    public String getVersion() 
+    {
         return version;
     }
 
-    public String getRelease() {
+    public String getRelease() 
+    {
         return release;
     }
 
-    public String getCompilerDownloadDir() {
+    public String getCompilerDownloadDir() 
+    {
         return compilerDownloadDir;
     }
 
-    public String getMainSourceDir() {
+    public String getMainSourceDir() 
+    {
         return mainSourceDir;
     }
 
-    public String getOutputDir() {
+    public String getOutputDir() 
+    {
         return outputDir;
     }
 
-    public String getMainModule() {
+    public String getMainModule() 
+    {
         return mainModule;
     }
 
-    public String getCompilerFlags() {
+    public String getCompilerFlags() 
+    {
         return compilerFlags;
     }
 
-    public String getReplModule() {
+    public String getReplModule() 
+    {
         return replModule;
     }
 
-    private String getFieldValue(Field field) {
-        try {
+    public String getCompileItems() 
+    {
+        return compileItems;
+    }
+
+    private String getFieldValue(Field field) 
+    {
+        try 
+        {
             return field.get(this).toString();
-        } catch (IllegalAccessException | IllegalArgumentException e) {
+        } catch (IllegalAccessException | IllegalArgumentException e) 
+        {
             throw new RuntimeException(e.getMessage(), e.getCause());
         }
     }
 
-    private Field getField(String fieldName) {
-        try {
+    private Field getField(String fieldName) 
+    {
+        try 
+        {
             return FregeDTO.class.getField(fieldName);
-        } catch (NoSuchFieldException e) {
-            throw new RuntimeException(
-                    String.format(
+        } catch (NoSuchFieldException e) 
+        {
+            throw new RuntimeException
+                (
+                    String.format
+                    (
                         "Field %s not found in class %s",
-                        e.getMessage(), FregeDTO.class.getName()),
-                    e.getCause());
+                        e.getMessage(), FregeDTO.class.getName()
+                    ),
+                    e.getCause()
+                );
         }
     }
 
-    private boolean isEmpty(Field field) {
+    private boolean isEmpty(Field field) 
+    {
         return getFieldValue(field).isEmpty();
     }
 
-    private String toKeyValuePairs(Field field) {
+    private String toKeyValuePairs(Field field) 
+    {
         return String.format("%s = %s", field.getName(), getFieldValue(field));
     }
 
-    private boolean isGetterProperty(Method method) {
+    private boolean isGetterProperty(Method method) 
+    {
         return method.getName().startsWith("get") &&
                method.getReturnType().getName().contains("Property");
     }
 
-    private String stripGetPrefixAndDecapitalize(String s) {
+    private String stripGetPrefixAndDecapitalize(String s) 
+    {
         return Character.toLowerCase(s.charAt(3)) + s.substring(4);
     }
 
-    public String toBuildFile() {
+    public String toBuildFile() 
+    {
         Stream<Field> fields =
-            Arrays.stream(FregeExtension.class.getMethods())
-            .filter(m -> isGetterProperty(m))
-            .map(m -> stripGetPrefixAndDecapitalize(m.getName()))
-            .map(name -> getField(name));
+        Arrays.stream(FregeExtension.class.getMethods())
+        .filter(m -> isGetterProperty(m))
+        .map(m -> stripGetPrefixAndDecapitalize(m.getName()))
+        .map(name -> getField(name));
+        
         return fields
-               .filter(f -> !isEmpty(f))
-               .map(f -> toKeyValuePairs(f))
-               .collect(Collectors.joining("\n  "));
+        .filter(f -> !isEmpty(f))
+        .map(f -> toKeyValuePairs(f))
+        .collect(Collectors.joining("\n  "));
     }
 }

--- a/src/test/java/ch/fhnw/thga/gradleplugins/FregeDTOBuilder.java
+++ b/src/test/java/ch/fhnw/thga/gradleplugins/FregeDTOBuilder.java
@@ -1,14 +1,16 @@
 package ch.fhnw.thga.gradleplugins;
 
-public final class FregeDTOBuilder implements Builder {
-    private String version = "";
-    private String release = "";
+public final class FregeDTOBuilder implements Builder 
+{
+    private String version             = "";
+    private String release             = "";
     private String compilerDownloadDir = "";
-    private String mainSourceDir = "";
-    private String outputDir = "";
-    private String mainModule = "";
-    private String compilerFlags = "";
-    private String replModule = "";
+    private String mainSourceDir       = "";
+    private String outputDir           = "";
+    private String mainModule          = "";
+    private String compilerFlags       = "";
+    private String replModule          = "";
+    private String compileItems        = "";
 
     private FregeDTOBuilder() {}
 
@@ -17,49 +19,59 @@ public final class FregeDTOBuilder implements Builder {
         return new FregeDTOBuilder();
     }
 
+    public static Builder latestVersionBuilder()
+    {
+        return 
+        builder()
+        .version("'3.25.84'")
+        .release("'3.25alpha'");
+    }
 
     @Override
-    public Builder version(String version) {
+    public Builder version(String version) 
+    {
         this.version = version;
         return this;
-
     }
 
     @Override
-    public Builder release(String release) {
+    public Builder release(String release) 
+    {
         this.release = release;
         return this;
-
     }
 
     @Override
-    public Builder compilerDownloadDir(String downloadDir) {
+    public Builder compilerDownloadDir(String downloadDir) 
+    {
         this.compilerDownloadDir = downloadDir;
         return this;
-
     }
 
     @Override
-    public Builder mainSourceDir(String mainSourceDir) {
+    public Builder mainSourceDir(String mainSourceDir) 
+    {
         this.mainSourceDir = mainSourceDir;
         return this;
-
     }
 
     @Override
-    public Builder outputDir(String outputDir) {
+    public Builder outputDir(String outputDir) 
+    {
         this.outputDir = outputDir;
         return this;
     }
 
     @Override
-    public Builder mainModule(String mainModule) {
+    public Builder mainModule(String mainModule) 
+    {
         this.mainModule = mainModule;
         return this;
     }
 
     @Override
-    public Builder compilerFlags(String compilerFlags) {
+    public Builder compilerFlags(String compilerFlags) 
+    {
         this.compilerFlags = compilerFlags;
         return this;
     }
@@ -71,8 +83,17 @@ public final class FregeDTOBuilder implements Builder {
         return this;
     }
 
-    public FregeDTO build() {
-        return new FregeDTO(
+    @Override
+    public Builder compileItems(String compileItems)
+    {
+        this.compileItems = compileItems;
+        return this;
+    }
+
+    public FregeDTO build() 
+    {
+        return new FregeDTO
+        (
             version,
             release,
             compilerDownloadDir,
@@ -80,6 +101,8 @@ public final class FregeDTOBuilder implements Builder {
             outputDir,
             mainModule,
             compilerFlags,
-            replModule);
+            replModule,
+            compileItems
+        );
     }
 }


### PR DESCRIPTION
Fixes #34.

### Breaking Change:
Removes the `--compileItem` command line option.

I switched from `Property<String>` -> `ListProperty<String>` to support
multiple compile items. Unfortunately but understandably, Gradle
does not support (multiple) command line options with the `ListProperty` [type](https://github.com/gradle/gradle/issues/10517).

In the end, the core input format of Gradle is not command
line arguments but a `build.gradle`.

### Improvements
- refactors ReplFrege Task